### PR TITLE
Fix issue with hyperlinks xml tag being written to WorksheetXml when no hyperlinks exist in the worksheet

### DIFF
--- a/EPPlus/ExcelWorksheet.cs
+++ b/EPPlus/ExcelWorksheet.cs
@@ -3986,13 +3986,14 @@ namespace OfficeOpenXml
                 //foreach (ulong cell in _hyperLinks)
                 while(cse.Next())
                 {
-                    if (first)
+                    var uri = _hyperLinks.GetValue(cse.Row, cse.Column);
+                    if (first && uri != null)
                     {
                         sw.Write("<hyperlinks>");
                         first = false;
                     }
+
                     //int row, col;
-                    var uri = _hyperLinks.GetValue(cse.Row, cse.Column);
                     //ExcelCell cell = _cells[cellId] as ExcelCell;
                     if (uri is ExcelHyperLink && !string.IsNullOrEmpty((uri as ExcelHyperLink).ReferenceAddress))
                     {


### PR DESCRIPTION
-- Copied from Codeplex --

While working with EPPlus I noticed an issue with excels which have had their hyperlinks removed from a worksheet. Currently when you remove all hyperlinks from a sheet an empty hyperlinks tag is still written to the Worksheet Xml. Having this empty tag was causing a notification of the file being corrupt (Was recoverable) when opened in excel. 

I added an extra check within the ExcelWorksheet.UpdateHyperLinks method to only place the hyperlinks tag once a non-null Uri is encountered.

Let me know if you need any other details or if you think this change will have a larger impact that anticipated.