### PR TITLE
Conditional Formating AddThreeIconSet gte

### DIFF
--- a/EPPlus/ConditionalFormatting/ExcelConditionalFormattingConstants.cs
+++ b/EPPlus/ConditionalFormatting/ExcelConditionalFormattingConstants.cs
@@ -108,6 +108,7 @@ namespace OfficeOpenXml.ConditionalFormatting
       internal const string Tint = "tint";
       internal const string Type = "type";
       internal const string Val = "val";
+      internal const string Gte = "gte";
     }
     #endregion Attributes
 
@@ -165,7 +166,8 @@ namespace OfficeOpenXml.ConditionalFormatting
       internal const string TintAttribute = "@" + Attributes.Tint;
       internal const string TypeAttribute = "@" + Attributes.Type;
       internal const string ValAttribute = "@" + Attributes.Val;
-    }
+      internal const string GteAttribute = "@" + Attributes.Gte;
+        }
     #endregion XML Paths
 
     #region Rule Type ST_CfType §18.18.12 (with small EPPlus changes)

--- a/EPPlus/ConditionalFormatting/ExcelConditionalFormattingIconDatabarValue.cs
+++ b/EPPlus/ConditionalFormatting/ExcelConditionalFormattingIconDatabarValue.cs
@@ -292,10 +292,31 @@ namespace OfficeOpenXml.ConditionalFormatting
 			}
 		}
 
-		/// <summary>
-		/// Get/Set the 'cfvo' node @val attribute
-		/// </summary>
-		public Double Value
+        /// <summary>
+        /// Get/Set the 'cfvo' node @gte attribute
+        /// </summary>
+        public bool GreaterThanOrEqualTo
+        {
+            get
+            {
+                return GetXmlNodeBool(ExcelConditionalFormattingConstants.Paths.GteAttribute);
+            }
+
+            set
+            {
+                SetXmlNodeString(  
+                    ExcelConditionalFormattingConstants.Paths.GteAttribute,
+                    (value == false) ? "0" : string.Empty,
+                    true);
+            }
+        }
+
+
+
+        /// <summary>
+        /// Get/Set the 'cfvo' node @val attribute
+        /// </summary>
+        public Double Value
 		{
 			get
 			{


### PR DESCRIPTION
This is a simple solution to the issue I posted here: https://github.com/JanKallman/EPPlus/issues/16

The GreaterThanOrEqualTo property allows the use of Greater and Greater Or Equal in Conditional Formatting with 3 icons set (cf Rule Type: eExcelconditionalFormatting3IconsSetType)

I hope that it's good enough.
Thanks