### PR TITLE
added ExcelPivotTable.ColumnHeaderCaption property

### DIFF
--- a/EPPlus/Table/PivotTable/ExcelPivotTable.cs
+++ b/EPPlus/Table/PivotTable/ExcelPivotTable.cs
@@ -741,6 +741,20 @@ namespace OfficeOpenXml.Table.PivotTable
             }
         }
         /// <summary>
+        /// Specifies the string to be displayed in column header in compact mode.
+        /// </summary>
+        public string ColumnHeaderCaption
+        {
+            get
+            {
+                return GetXmlNodeString("@colHeaderCaption");
+            }
+            set
+            {
+                SetXmlNodeString("@colHeaderCaption", value);
+            }
+        }
+        /// <summary>
         /// Specifies the string to be displayed in cells with no value
         /// </summary>
         public string MissingCaption

--- a/EPPlusTest/WorkSheet.cs
+++ b/EPPlusTest/WorkSheet.cs
@@ -2164,6 +2164,9 @@ namespace EPPlusTest
             pt.RowFields.Add(pt.Fields[2]);
             pt.RowFields.Add(pt.Fields[4]);
             pt.DataOnRows = true;
+            pt.ColumnHeaderCaption = "Column Caption";
+            pt.RowHeaderCaption = "Row Caption";
+
             //wsPivot10.Drawings.AddChart("Pivotchart10", OfficeOpenXml.Drawing.Chart.eChartType.BarStacked3D, pt);
 
         }


### PR DESCRIPTION
-[X] Write a detailed description of your what you have implemented or changed.
-[X] Attach unit tests in the testproject to test implemented functionallity.
-[X] Make sure no tests fail in the test project.
-[X] Verify that you only check in the files intended for the pull request.
-[X] Do not change dotnet version, include new dependencies unless you explicitly talked to someone in the project about doing so.

I added ExcelPivotTable.ColumnHeaderCaption property which is similar to the existing RowHeaderCaption property. It allows users to specify the caption for pivot table column headers.

I discovered the solution to my problem on this question:
https://stackoverflow.com/questions/14444744/how-to-set-column-name-on-pivot-table