### PR TITLE
fixed misspelling in ExcelPivotTable.ColumnGrandTotals

### DIFF
--- a/EPPlus/Table/PivotTable/ExcelPivotTable.cs
+++ b/EPPlus/Table/PivotTable/ExcelPivotTable.cs
@@ -486,7 +486,22 @@ namespace OfficeOpenXml.Table.PivotTable
         /// <summary>
         /// If the grand totals should be displayed for the PivotTable columns
         /// </summary>
+        [Obsolete("Use correctly spelled property 'ColumnGrandTotals'")]
         public bool ColumGrandTotals
+        {
+            get
+            {
+                return ColumnGrandTotals;
+            }
+            set
+            {
+                ColumnGrandTotals = value;
+            }
+        }
+        /// <summary>
+        /// If the grand totals should be displayed for the PivotTable columns
+        /// </summary>
+        public bool ColumnGrandTotals
         {
             get
             {
@@ -496,7 +511,7 @@ namespace OfficeOpenXml.Table.PivotTable
             {
                 SetXmlNodeBool("@colGrandTotals", value);
             }
-        }        
+        }
         /// <summary>
         /// If the grand totals should be displayed for the PivotTable rows
         /// </summary>

--- a/EPPlusTest/Issues.cs
+++ b/EPPlusTest/Issues.cs
@@ -844,7 +844,7 @@ namespace EPPlusTest
                 var wsAuditPivot = ep.Workbook.Worksheets.Add("Pivot1");
 
                 var pivotTable1 = wsAuditPivot.PivotTables.Add(wsAuditPivot.Cells["A7:C30"], data, "PivotAudit1");
-                pivotTable1.ColumGrandTotals = true;
+                pivotTable1.ColumnGrandTotals = true;
                 var rowField = pivotTable1.RowFields.Add(pivotTable1.Fields["INVOICE_DATE"]);
 
 
@@ -883,7 +883,7 @@ namespace EPPlusTest
                 var wsAuditPivot = ep.Workbook.Worksheets.Add("Pivot2");
 
                 var pivotTable1 = wsAuditPivot.PivotTables.Add(wsAuditPivot.Cells["A7:C30"], data, "PivotAudit2");
-                pivotTable1.ColumGrandTotals = true;
+                pivotTable1.ColumnGrandTotals = true;
                 var rowField = pivotTable1.RowFields.Add(pivotTable1.Fields["INVOICE_DATE"]);
 
 


### PR DESCRIPTION
-[X] Write a detailed description of your what you have implemented or changed.
-[X] Attach unit tests in the testproject to test implemented functionallity.
-[X] Make sure no tests fail in the test project.
-[X] Verify that you only check in the files intended for the pull request.
-[X] Do not change dotnet version, include new dependencies unless you explicitly talked to someone in the project about doing so.

I fixed a misspelling of ExcelPivotTable.ColumnGrandTotals property. I left the misspelled property and added the Obsolete attribute so that it is not a breaking change and will generate warnings for users of the property.