### PR TITLE
When loading cells: flag cells containing array formula

### DIFF
--- a/EPPlus/ExcelWorksheet.cs
+++ b/EPPlus/ExcelWorksheet.cs
@@ -1363,6 +1363,8 @@ namespace OfficeOpenXml
                         _formulas.SetValue(address._fromRow, address._fromCol, afIndex);
                         SetValueInner(address._fromRow, address._fromCol, null);
                         _sharedFormulas.Add(afIndex, new Formulas(SourceCodeTokenizer.Default) { Index = afIndex, Formula = formula, Address = aAddress, StartRow = address._fromRow, StartCol = address._fromCol, IsArray = true });
+
+                        _flags.SetFlagValue(address._fromRow, address._fromCol, true, CellFlags.ArrayFormula);
                     }
                     else // ??? some other type
                     {

--- a/EPPlusTest/Issues.cs
+++ b/EPPlusTest/Issues.cs
@@ -1679,5 +1679,36 @@ namespace EPPlusTest
                 
             }
         }
+
+        [TestMethod]
+        public void Issue63() // See https://github.com/JanKallman/EPPlus/issues/63
+        {
+            // Prepare
+            var newFile = new FileInfo(Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.xlsx"));
+            try
+            {
+                using (var package = new ExcelPackage(newFile))
+                {
+                    ExcelWorksheet ws = package.Workbook.Worksheets.Add("ArrayTest");
+                    ws.Cells["A1"].Value = 1;
+                    ws.Cells["A2"].Value = 2;
+                    ws.Cells["A3"].Value = 3;
+                    ws.Cells["B1:B3"].CreateArrayFormula("A1:A3");
+                    package.Save();
+                }
+                Assert.IsTrue(File.Exists(newFile.FullName));
+
+                // Test: basic support to recognize array formulas after reading Excel workbook file
+                using (var package = new ExcelPackage(newFile))
+                {
+                    Assert.AreEqual("A1:A3", package.Workbook.Worksheets["ArrayTest"].Cells["B1"].Formula);
+                    Assert.IsTrue(package.Workbook.Worksheets["ArrayTest"].Cells["B1"].IsArrayFormula);
+                }
+            }
+            finally
+            {
+                File.Delete(newFile.FullName);
+            }
+        }
     }
 }


### PR DESCRIPTION
Array formulas are not yet supported (according to the comment in `LoadCells (Xmlreader)` at line 1358 `else if (t == "array")`), but there is some basic support.

Unfortunately, however, at this point there is no way to recognize that a formula was originally an array formula. Solve this by setting the `CellFlags.ArrayFormula` flag for the relevant cell.