### PR TITLE
Pivot cond formatting fix

### DIFF
--- a/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingRule.cs
+++ b/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingRule.cs
@@ -53,6 +53,7 @@ namespace OfficeOpenXml.ConditionalFormatting
     #region Private Properties
     private eExcelConditionalFormattingRuleType? _type;
     private ExcelWorksheet _worksheet;
+    private static string pivotTag = "@pivot";
 
     /// <summary>
     /// Sinalize that we are in a Cnaging Priorities opeartion so that we won't enter
@@ -99,23 +100,47 @@ namespace OfficeOpenXml.ConditionalFormatting
 
       if (itemElementNode == null)
       {
+        
+        string conditionFormattingTag = address.IsPivot ? 
+            string.Format(
+            "{0}[{1}='{2}']/{1}='{2}'/{6}='{7}'/{3}[{4}='{5}']/{4}='{5}'",
+            //{0}
+            ExcelConditionalFormattingConstants.Paths.ConditionalFormatting,
+            // {1}
+            ExcelConditionalFormattingConstants.Paths.SqrefAttribute,
+            // {2}
+            address.AddressSpaceSeparated,          //CF node don't what to have comma between multi addresses, use space instead.
+            // {3}
+            ExcelConditionalFormattingConstants.Paths.CfRule,
+            //{4}
+            ExcelConditionalFormattingConstants.Paths.PriorityAttribute,
+            //{5}
+            priority,
+            //{6}
+            pivotTag,
+            //{7}
+            "1") 
+            :
+            string.Format(
+            "{0}[{1}='{2}']/{1}='{2}'/{3}[{4}='{5}']/{4}='{5}'",
+            //{0}
+            ExcelConditionalFormattingConstants.Paths.ConditionalFormatting,
+            // {1}
+            ExcelConditionalFormattingConstants.Paths.SqrefAttribute,
+            // {2}
+            address.AddressSpaceSeparated,          //CF node don't what to have comma between multi addresses, use space instead.
+            // {3}
+            ExcelConditionalFormattingConstants.Paths.CfRule,
+            //{4}
+            ExcelConditionalFormattingConstants.Paths.PriorityAttribute,
+            //{5}
+            priority);
+          
         // Create/Get the <cfRule> inside <conditionalFormatting>
         itemElementNode = CreateComplexNode(
           _worksheet.WorksheetXml.DocumentElement,
-          string.Format(
-            "{0}[{1}='{2}']/{1}='{2}'/{3}[{4}='{5}']/{4}='{5}'",
-          //{0}
-            ExcelConditionalFormattingConstants.Paths.ConditionalFormatting,
-          // {1}
-            ExcelConditionalFormattingConstants.Paths.SqrefAttribute,
-          // {2}
-            address.AddressSpaceSeparated,          //CF node don't what to have comma between multi addresses, use space instead.
-          // {3}
-            ExcelConditionalFormattingConstants.Paths.CfRule,
-          //{4}
-            ExcelConditionalFormattingConstants.Paths.PriorityAttribute,
-          //{5}
-            priority));
+          conditionFormattingTag
+          );
       }
 
       // Point to <cfRule>

--- a/EPPlus/ExcelAddress.cs
+++ b/EPPlus/ExcelAddress.cs
@@ -1257,6 +1257,14 @@ namespace OfficeOpenXml
     /// </summary>
     public class ExcelAddress : ExcelAddressBase
     {
+        
+        private bool isPivot;
+
+        bool isPivotAddress()
+        {
+            return isPivot;
+        }
+        
         internal ExcelAddress()
             : base()
         {
@@ -1271,6 +1279,12 @@ namespace OfficeOpenXml
         public ExcelAddress(string address)
             : base(address)
         {
+        }
+
+         public ExcelAddress(string address, bool pivot)
+            : base(address)
+        {
+            isPivot = pivot;
         }
         
         internal ExcelAddress(string ws, string address)

--- a/EPPlus/ExcelAddress.cs
+++ b/EPPlus/ExcelAddress.cs
@@ -1256,15 +1256,7 @@ namespace OfficeOpenXml
     /// Range address with the address property readonly
     /// </summary>
     public class ExcelAddress : ExcelAddressBase
-    {
-        
-        private bool isPivot;
-
-        bool isPivotAddress()
-        {
-            return isPivot;
-        }
-        
+    {                       
         internal ExcelAddress()
             : base()
         {
@@ -1274,23 +1266,17 @@ namespace OfficeOpenXml
         public ExcelAddress(int fromRow, int fromCol, int toRow, int toColumn)
             : base(fromRow, fromCol, toRow, toColumn)
         {
-            _ws = "";
+            _ws = "";           
         }
         public ExcelAddress(string address)
             : base(address)
-        {
-        }
-
-         public ExcelAddress(string address, bool pivot)
-            : base(address)
-        {
-            isPivot = pivot;
-        }
+        {         
+        }       
         
         internal ExcelAddress(string ws, string address)
             : base(address)
         {
-            if (string.IsNullOrEmpty(_ws)) _ws = ws;
+            if (string.IsNullOrEmpty(_ws)) _ws = ws;            
         }
         internal ExcelAddress(string ws, string address, bool isName)
             : base(address, isName)
@@ -1323,6 +1309,20 @@ namespace OfficeOpenXml
                 ChangeAddress();
             }
         }
+
+        public bool IsPivot
+        {             
+             get 
+             {
+                return isPivot;
+             }
+             set 
+             {
+                isPivot = value;
+             }
+        }
+
+        private bool isPivot; 
     }
     public class ExcelFormulaAddress : ExcelAddressBase
     {


### PR DESCRIPTION
-[] I found an issue for Office 2007 - namely using ConditionalFormatting as is for PivotTables does not work in Pffice 2007 - namely Excel still did not show Red Color for negative numbers which was my conditional rule.

However when manually setting Red Color for negative numbers in Excel 2007 Pivot tables via Conditional Formatting all worked

After dumping xmls from manual and auto versions i found the difference, namely in case of working manual verion Conditional Formatting tag also included reference "pivot=1"

So, in this proposed fix i added public property in ExcelAddress class to specify whether this range is withing Pivot data.
In ExcelConditionalFormattingRule constructor i added a check for Pivot and adding this proper fix in a tag string for Conditional Formatting.

From my application i selected Pivot address range, changed propety IsPivot = true and after that Excel 2007 has shown up red negative numbers as expected

-[] As described above fix worked in an integrated test of an application with modified library
-[] Make sure no tests fail in the test project - checked
-[] Verify that you only check in the files intended for the pull request - checked
-[] Do not change dotnet version, include new dependencies unless you explicitly talked to someone in the project about doing so - checked
