### PR TITLE
Fix the bug that cell.Text wasn't correctly formatted when there's \%…

### DIFF
--- a/EPPlus/Style/XmlAccess/ExcelNumberFormatXml.cs
+++ b/EPPlus/Style/XmlAccess/ExcelNumberFormatXml.cs
@@ -383,7 +383,7 @@ namespace OfficeOpenXml.Style.XmlAccess
 
                                 if (prevBslsh)
                                 {
-                                    if (c == '.' || c == ',')
+                                    if (c == '.' || c == ',' || c == '%')
                                     {
                                         sb.Append('\\');
                                     }                                    

--- a/EPPlusTest/WorksheetsTests.cs
+++ b/EPPlusTest/WorksheetsTests.cs
@@ -288,6 +288,18 @@ namespace EPPlusTest
             Assert.IsNull(wks.Cells[2, 3].Value);
         }
 
+
+	    [TestMethod]
+	    public void DisplayCustomFormatTest()
+	    {
+	        var wks = workbook.Worksheets.Add("test");
+	        wks.Cells[2, 2].Value = 50.1M;
+	        wks.Cells[2, 2].Style.Numberformat.Format = "#,###.00\\%;\\-#,###.00\\%;";
+
+	        Assert.AreEqual("50.10%", wks.Cells[2, 2].Text);
+	    }
+
+
         private static void CompareOrderOfWorksheetsAfterSaving(ExcelPackage editedPackage)
 		{
 			var packageStream = new MemoryStream();


### PR DESCRIPTION
fixes #84 