### PR TITLE
Should not change ContentType based on the VbaProject file availability_IssueNo_112

### DIFF
--- a/EPPlus/ExcelWorkbook.cs
+++ b/EPPlus/ExcelWorkbook.cs
@@ -768,21 +768,6 @@ namespace OfficeOpenXml
 				throw new InvalidOperationException("The workbook must contain at least one worksheet");
 
 			DeleteCalcChain();
-
-            if (_vba == null && !_package.Package.PartExists(new Uri(ExcelVbaProject.PartUri, UriKind.Relative)))
-            {
-                if (Part.ContentType != ExcelPackage.contentTypeWorkbookDefault)
-                {
-                    Part.ContentType = ExcelPackage.contentTypeWorkbookDefault;
-                }
-            }
-            else
-            {
-                if (Part.ContentType != ExcelPackage.contentTypeWorkbookMacroEnabled)
-                {
-                    Part.ContentType = ExcelPackage.contentTypeWorkbookMacroEnabled;
-                }
-            }
 			
             UpdateDefinedNamesXml();
 


### PR DESCRIPTION
**Issue Details:**
ContentType is serialized as spreedsheeml instead of macro-enabled in the ContentType.xml based on vba project.

**Fix Details**
ContentType cannot be serialized based on the VBA project, so remove the code snippet.

**Test Cases**
No test cases added, as it is corruption issues.
