### PR TITLE
Issue184

### DIFF
--- a/EPPlus/ExcelPackage.cs
+++ b/EPPlus/ExcelPackage.cs
@@ -792,11 +792,20 @@ namespace OfficeOpenXml
 		{
             if(_package != null)
             {
-		if (_isExternalStream==false && _stream != null && (_stream.CanRead || _stream.CanWrite))
+		        if (_isExternalStream==false && _stream != null && (_stream.CanRead || _stream.CanWrite))
                 {
-                    _stream.Close();
+                    // Only close _stream if it is NOT external. Note that CloseStream()
+                    // comments even state "Close the internal stream."
+                    CloseStream();
+                    // The only advantage that might exist to call CloseStream()
+                    // which in turn calls both _stream.Close() and _stream.Dispose()
+                    // is if someone didn't treat these as Microsoft did in the Stream class.
+                    // In Stream, Dispose() calls Close() and Close() has 2 lines:
+                    // Dispose(true);
+                    // GC.SuppressFinalize(this);
+                    //_stream.Close();
                 }
-                CloseStream();
+                //CloseStream();
                 _package.Close();
                 if(_isExternalStream==false) ((IDisposable)_stream).Dispose();
                 if(_workbook != null)

--- a/EPPlusTest/Issues.cs
+++ b/EPPlusTest/Issues.cs
@@ -1996,5 +1996,35 @@ namespace EPPlusTest
                 var r = ws.Cells["A4"].Text;
             }
         }
+
+
+        /// <summary>
+        /// Creating a new ExcelPackage with an external stream should not dispose of 
+        /// that external stream. That is the responsibility of the caller.
+        /// Note: This test would pass with EPPlus 4.1.1. In 4.5.1 the line CloseStream() was added
+        /// to the ExcelPackage.Dispose() method. That line is redundant with the line before, 
+        /// _stream.Close() except that _stream.Close() is only called if the _stream is NOT
+        /// an External Stream (and several other conditions).
+        /// Note that CloseStream() doesn't do anything different than _stream.Close().
+        /// </summary>
+        [TestMethod]
+        public void Issue184_Disposing_External_Stream()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+
+            using (var excelPackage = new ExcelPackage(stream))
+            {
+                var worksheet = excelPackage.Workbook.Worksheets.Add("Issue 184");
+                worksheet.Cells[1, 1].Value = "Hello EPPlus!";
+                excelPackage.SaveAs(stream);
+
+                // Act
+            } // This dispose should not dispose of stream.
+
+            // Assert
+            Assert.IsTrue(stream.Length > 0);
+        }
+
     }
 }


### PR DESCRIPTION
This has two commits. The first demonstrates that an External stream is disposed when that was not the behavior of EPPlus 4.1.1 nor does that appear to be the intent. The next commit makes a recommended change that does then cause that unit test to work. This also causes code we have that worked with 4.1.1 to work again.
Note that issue127 unit test always failed on my machine. I'm not sure if I'm missing a file or something.
I left lots of comments in ExcelPackage.cs that can probably be deleted if this is approved.
(Fingers Crossed... I'm really a Git newbie having only used it since Oct, and really only with our corporate project. Suggestions for improvement greatly appreciated.)
