### PR TITLE
new constructor and SaveAs overloads

### DIFF
--- a/EPPlus/ExcelPackage.cs
+++ b/EPPlus/ExcelPackage.cs
@@ -178,6 +178,7 @@ namespace OfficeOpenXml
         internal const bool preserveWhitespace=false;
         Stream _stream = null;
         private bool _isExternalStream=false;
+        private bool _isReadOnly = false;
         internal class ImageInfo
         {
             internal string Hash { get; set; }
@@ -281,6 +282,7 @@ namespace OfficeOpenXml
             Init();
             if (readOnly)
             {
+                _isReadOnly = true;
                 FileStream fs = new FileStream(newFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 
                 if (fs.Length == 0)
@@ -866,6 +868,10 @@ namespace OfficeOpenXml
         /// </summary>
         public void Save()
         {
+            if (_isReadOnly)
+            {
+                throw new InvalidOperationException("Error saving file, the package was open as read only");
+            }
             try
             {
                 if (_stream is MemoryStream && _stream.Length > 0)

--- a/EPPlus/ExcelPackage.cs
+++ b/EPPlus/ExcelPackage.cs
@@ -264,6 +264,44 @@ namespace OfficeOpenXml
             ConstructNewFile(null);
         }
         /// <summary>
+        /// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
+        /// </summary>
+        /// <param name="newFile">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
+        public ExcelPackage(string newFile) : this(newFile, false)
+        {
+            
+        }
+        /// <summary>
+        /// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
+        /// </summary>
+        /// <param name="newFile">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
+        /// <param name="readOnly">Set to true to open a document already open in Excel</param>
+        public ExcelPackage(string newFile, bool readOnly)
+        {
+            Init();
+            if (readOnly)
+            {
+                FileStream fs = new FileStream(newFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                
+                if (fs.Length == 0)
+                {
+                    _stream = fs;
+                    _isExternalStream = false;
+                    ConstructNewFile(null);
+                }
+                else
+                {
+                    Load(fs, new MemoryStream(), null);
+                }               
+            }
+            else
+            {
+                File = new FileInfo(newFile);
+                ConstructNewFile(null);
+            }
+        }
+            
+        /// <summary>
 		/// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
 		/// </summary>
 		/// <param name="newFile">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
@@ -931,6 +969,15 @@ namespace OfficeOpenXml
         {
             File = file;
             Save();
+        }
+        /// <summary>
+        /// Saves the workbook to a new file
+        /// The package is closed after it has been saved        
+        /// </summary>
+        /// <param name="file">The file location</param>
+        public void SaveAs(string file)
+        {
+            SaveAs(new FileInfo(file));
         }
         /// <summary>
         /// Saves the workbook to a new file

--- a/EPPlusTest/WorkSheet.cs
+++ b/EPPlusTest/WorkSheet.cs
@@ -333,6 +333,77 @@ namespace EPPlusTest
             instream.Close();
         }
 
+        [TestMethod]
+        public void ReadWorksheetFromPathString()
+        {
+            using(ExcelPackage pck = new ExcelPackage(_worksheetPath + @"Worksheet.xlsx"))
+            {
+                var ws = pck.Workbook.Worksheets["Perf"];
+                Assert.AreEqual(ws.Cells["H6"].Formula, "B5+B6");
+
+                ws = pck.Workbook.Worksheets["Comment"];
+                var comment = ws.Cells["B2"].Comment;
+
+                Assert.AreNotEqual(comment, null);
+                Assert.AreEqual(comment.Author, "Jan Källman");
+            }
+        }
+
+        [TestMethod]
+        public void ReadWorksheetFromPathStringReadOnly()
+        {
+            string filePath = _worksheetPath + @"Worksheet.xlsx";
+
+            //Simulates the Excel blocking the file
+            FileStream fs1 = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
+
+            using (ExcelPackage pck = new ExcelPackage(filePath, true))
+            {
+                var ws = pck.Workbook.Worksheets["Perf"];
+                Assert.AreEqual(ws.Cells["H6"].Formula, "B5+B6");
+
+                ws = pck.Workbook.Worksheets["Comment"];
+                var comment = ws.Cells["B2"].Comment;
+
+                Assert.AreNotEqual(comment, null);
+                Assert.AreEqual(comment.Author, "Jan Källman");
+            }
+
+            fs1.Dispose();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void ReadWorksheetFromPathStringReadOnlyException()
+        {
+            string filePath = _worksheetPath + @"Worksheet.xlsx";
+
+            //Simulates the Excel blocking the file
+            FileStream fs1 = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
+
+            using (ExcelPackage pck = new ExcelPackage(filePath, true))
+            {
+                var ws = pck.Workbook.Worksheets["Perf"];
+                ws.SetValue(1, 1, 1);
+                pck.Save();
+            }
+
+            fs1.Dispose();
+        }
+
+        [TestMethod]
+        public void SaveWorksheetFromPathString()
+        {
+            string filePath = _worksheetPath + @"WorksheetSaveString.xlsx";
+
+            using (ExcelPackage pck = new ExcelPackage())
+            {
+                var ws = pck.Workbook.Worksheets.Add("Sheet1");
+                ws.SetValue(1, 1, 1);
+                pck.SaveAs(filePath);
+            }
+        }
+
         [Ignore]
         [TestMethod]
         public void ReadStreamWithTemplateWorkSheet()


### PR DESCRIPTION
- Adds a new constructor that takes a string with the path to the file as argument.
- Adds a new constructor that takes a string with the path to the file and a bool indicating that it's read only as arguments.
   * This constructor allows to open files that are currently being in use by Excel and Closes #223 created by me
- Adds a SaveAs overload that takes a string with path as argument
- Adds Unit tests for this new overloads


-[X] Write a detailed description of your what you have implemented or changed.
-[X] Attach unit tests in the testproject to test implemented functionallity.
-[X] Make sure no tests fail in the test project.
-[X] Verify that you only check in the files intended for the pull request.
-[X] Do not change dotnet version, include new dependencies unless you explicitly talked to someone in the project about doing so.
