### PR TITLE
Access ExcelPackage from ExcelWorkbook

### DIFF
--- a/EPPlus/ExcelWorkbook.cs
+++ b/EPPlus/ExcelWorkbook.cs
@@ -295,6 +295,17 @@ namespace OfficeOpenXml
 		}
 		#endregion
 
+        /// <summary>
+        /// Provides access to ExcelPackage.
+        /// </summary>
+        public ExcelPackage ExcelPackage
+        {
+            get
+            {
+                return _package;
+            }
+        }
+
 		/// <summary>
 		/// Provides access to named ranges
 		/// </summary>


### PR DESCRIPTION
This allows users to be able to access ExcelPackage from ExcelWorkbook.

Access to ExcelPackage is added to ExcelWorkbook.  The reasoning for this is if users wish to abstract EPPlus into their own interface, they will be able to call functions such as Save, FileName, Name etc. from the workbook class which could seem more intuitive.