### PR TITLE
Fix generated file corruption for Pivot Tables with a named range as …

### DIFF
--- a/EPPlus/ExcelNamedRangeCollection.cs
+++ b/EPPlus/ExcelNamedRangeCollection.cs
@@ -180,7 +180,7 @@ namespace OfficeOpenXml
             {
                 if (colFrom <= namedRange.Start.Column)
                 {
-                    var newAddress = ExcelCellBase.GetAddress(namedRange.Start.Row, namedRange.Start.Column +cols, namedRange.End.Row, namedRange.End.Column + cols);
+                    var newAddress = ExcelCellBase.GetAddress(namedRange.Start.Row, Math.Min(namedRange.Start.Column + cols, ExcelPackage.MaxColumns), namedRange.End.Row, Math.Min(namedRange.End.Column + cols, ExcelPackage.MaxColumns));
                     namedRange.Address = BuildNewAddress(namedRange, newAddress);
                 }
                 else if (colFrom <= namedRange.End.Column && namedRange.End.Column + cols < ExcelPackage.MaxColumns)
@@ -208,7 +208,7 @@ namespace OfficeOpenXml
             {
                 if (rowFrom <= namedRange.Start.Row)
                 {
-                    var newAddress = ExcelCellBase.GetAddress(namedRange.Start.Row + rows, namedRange.Start.Column, namedRange.End.Row + rows, namedRange.End.Column);
+                    var newAddress = ExcelCellBase.GetAddress(Math.Min(namedRange.Start.Row + rows, ExcelPackage.MaxRows), namedRange.Start.Column, Math.Min(namedRange.End.Row + rows, ExcelPackage.MaxRows), namedRange.End.Column);
                     namedRange.Address = BuildNewAddress(namedRange, newAddress); 
                 }
                 else if (rowFrom <= namedRange.End.Row && namedRange.End.Row+rows <= ExcelPackage.MaxRows)

--- a/EPPlus/ExcelWorksheet.cs
+++ b/EPPlus/ExcelWorksheet.cs
@@ -3330,8 +3330,11 @@ namespace OfficeOpenXml
                 if (r != null)  //Source does not exist
                 {
                     ExcelTable t = null;
-                    if (pt.CacheDefinition.SourceRange.IsName)
-                    {
+					// Would "true" only if the SourceRange is an ExcelNamedRange that refers to another Named Range, 
+					// in other words this condition does not  holw true even if the pivot table source is a named range (unless that named range refers to another named range):
+					// if (pt.CacheDefinition.SourceRange.IsName)
+					if (pt.CacheDefinition.SourceRange is ExcelNamedRange && !string.IsNullOrEmpty(((ExcelNamedRange)pt.CacheDefinition.SourceRange).Name))
+					{
                         //Named range, set name
                         pt.CacheDefinition.DeleteNode(ExcelPivotCacheDefinition._sourceAddressPath); //Remove any address if previously set.
                         pt.CacheDefinition.SetXmlNodeString(ExcelPivotCacheDefinition._sourceNamePath, ((ExcelNamedRange)pt.CacheDefinition.SourceRange).Name);


### PR DESCRIPTION
We've been having trouble generating some Excel workbooks with all versions after 4.0.5 (1/8/2016, f3e3852c718e0109e7384fa781491dc4cc51a071).

After several hours of research we tracked the issue down to two problems:

1) Changeset 92b972b9d8b3d90f3ff263e5cdd1493fea7d747c introduced a bug where, if a row is inserted on a worksheet that has a named range of the type "$C:$F", then EPPlus will redefine the range with an ending address that is greater than ExcelPackage.MaxRows. 

The problem is that ExcelWorksheet.InsertRow() calls ExcelNamedRangeCollection.InsertRows(), which redefines the named range with a new address `namedRange.Start.Row + rows` without checking if this will result in an invalid address. I've added some rudimentary checks but a better solution would be to return from ExcelNamedRangeCollection.InsertRows() if the named range is of the type "$C:$F" (i.e. a named column range). However, I don't see how this could be done easily, because ExcelNamedRange does not have any property like "IsColumnReference" (or whatever). The same holds for InsertColumns.

In any case the fix works. 

2) Changeset 7b78083d1a0060dae2e12ff642dbab2fe704c60f introduced a bug where, if a pivot table refers to a named range, then the "SourceNamePath" is replaced with a "SourceAddressPath", leading to a corrupt workbook. 

The problem is in ExcelWorksheet.SavePivotTables(), with this check:

`if (pt.CacheDefinition.SourceRange.IsName)`

This returns "false" even if the pivot table's source range is an ExcelNamedRange, because ExcelNamedRange.IsName only returns true if the named range refers to another named range (is that even possible?). 

I've replaced this with a more exact condition, which fixes the problem:

`if (pt.CacheDefinition.SourceRange is ExcelNamedRange && !string.IsNullOrEmpty(((ExcelNamedRange)pt.CacheDefinition.SourceRange).Name))`

But again, there may be a better approach. 

---
I've not added any unit tests as I've already spend 7+ hours tracking down these problems and am unfamiliar with how unit tests work on this project. The work was made more difficult by changeset 7b78083d1a0060dae2e12ff642dbab2fe704c60f which basically includes all files in the solution (with a minor change in the header) PLUS the one breaking change described in 2) above.

I believe this fix should help some of the folks who've commented on https://github.com/JanKallman/EPPlus/issues/38
