### PR TITLE
Issue 295 Fixed System.Xml.XmlException on calling PivotTables.Add with No-Escaped header cells

### DIFF
--- a/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
+++ b/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
@@ -34,6 +34,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml;
 using System.Linq;
+using System.Security;
 using OfficeOpenXml.Utils;
 namespace OfficeOpenXml.Table.PivotTable
 {
@@ -278,7 +279,8 @@ namespace OfficeOpenXml.Table.PivotTable
                 }
                 else
                 {
-                    xml += string.Format("<cacheField name=\"{0}\" numFmtId=\"0\">", sourceWorksheet.GetValueInner(sourceAddress._fromRow, col));
+                    var s = sourceWorksheet.GetValueInner(sourceAddress._fromRow, col).ToString();
+                    xml += string.Format("<cacheField name=\"{0}\" numFmtId=\"0\">", System.Security.SecurityElement.Escape(s));
                 }
                 //xml += "<sharedItems containsNonDate=\"0\" containsString=\"0\" containsBlank=\"1\" /> ";
                 xml += "<sharedItems containsBlank=\"1\" /> ";


### PR DESCRIPTION
This solves the bug of [issue 295](https://github.com/JanKallman/EPPlus/issues/295).

Change folloing codes when you test this request:

EPPlusSamples/Sample12.cs

+ Add the line following `var dataRange = ...` (I added at line 94)
     `wsData.Cells["E1"].Value = "<Name>";`
+ Change folloing code. "Name" to **"<Name>"**(I changed at line 115)
    `- pivotTable2.RowFields.Add(pivotTable2.Fields["Name"]);`
    `+ pivotTable2.RowFields.Add(pivotTable2.Fields["<Name>"]);`