### PR TITLE
Replace all leading tabs with 4 spaces.

### DIFF
--- a/EPPlus/CellStore.cs
+++ b/EPPlus/CellStore.cs
@@ -63,14 +63,14 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
     {
         internal IndexBase _searchIx=new IndexBase();
         public ColumnIndex ()
-	    {
+        {
             _pages=new PageIndex[CellStore<int>.PagesPerColumnMin];
             PageCount=0;
-	    }
+        }
         ~ColumnIndex()
-	    {
+        {
             _pages=null;            
-	    }
+        }
         internal int GetPosition(int Row)
         {
             var page = (short)(Row >> CellStore<int>.pageBits);
@@ -218,10 +218,10 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
     {
         internal IndexItem _searchIx = new IndexItem();
         public PageIndex()
-	    {
+        {
             Rows = new IndexItem[CellStore<int>.PageSizeMin];
             RowCount = 0;
-	    }
+        }
         public PageIndex(IndexItem[] rows, int count)
         {
             Rows = rows;
@@ -241,9 +241,9 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
             Offset = offset;
         }
         ~PageIndex()
-	    {
+        {
             Rows=null;
-	    }
+        }
         internal int Offset = 0;
         internal int IndexOffset
         {
@@ -343,18 +343,18 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
         internal IndexItem _searchItem = new IndexItem();
         internal int ColumnCount;
         public CellStore ()
-	    {
+        {
             _columnIndex = new ColumnIndex[ColSizeMin];
-	    }
+        }
         ~CellStore()
-	    {
+        {
             if (_values != null)
             {
                 _values.Clear();
                 _values = null;
             }
             _columnIndex=null;
-	    }
+        }
         internal int GetPosition(int Column)
         {
             if(Column < ColumnCount && _columnIndex[Column].Index==Column)      //Check if th column is lesser than

--- a/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingColorScaleGroup.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingColorScaleGroup.cs
@@ -37,13 +37,13 @@ using OfficeOpenXml.ConditionalFormatting;
 
 namespace OfficeOpenXml.ConditionalFormatting.Contracts
 {
-	/// <summary>
+    /// <summary>
   /// IExcelConditionalFormattingColorScaleGroup
-	/// </summary>
+    /// </summary>
   public interface IExcelConditionalFormattingColorScaleGroup
-		: IExcelConditionalFormattingRule
-	{
-		#region Public Properties
-		#endregion Public Properties
-	}
+        : IExcelConditionalFormattingRule
+    {
+        #region Public Properties
+        #endregion Public Properties
+    }
 }

--- a/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingDataBarGroup.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingDataBarGroup.cs
@@ -38,13 +38,13 @@ using System.Drawing;
 
 namespace OfficeOpenXml.ConditionalFormatting.Contracts
 {
-	/// <summary>
-	/// IExcelConditionalFormattingDataBar
-	/// </summary>
-	public interface IExcelConditionalFormattingDataBarGroup
+    /// <summary>
+    /// IExcelConditionalFormattingDataBar
+    /// </summary>
+    public interface IExcelConditionalFormattingDataBarGroup
         : IExcelConditionalFormattingRule
-	{
-		#region Public Properties
+    {
+        #region Public Properties
         /// <summary>
         /// ShowValue
         /// </summary>
@@ -63,5 +63,5 @@ namespace OfficeOpenXml.ConditionalFormatting.Contracts
         /// </summary>
         Color Color { get; set;}
         #endregion Public Properties
-	}
+    }
 }

--- a/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingIconSetGroup.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingIconSetGroup.cs
@@ -37,13 +37,13 @@ using OfficeOpenXml.ConditionalFormatting;
 
 namespace OfficeOpenXml.ConditionalFormatting.Contracts
 {
-	/// <summary>
-	/// IExcelConditionalFormattingIconSetGroup
-	/// </summary>
-	public interface IExcelConditionalFormattingIconSetGroup<T>
-		: IExcelConditionalFormattingRule
-	{
-		#region Public Properties
+    /// <summary>
+    /// IExcelConditionalFormattingIconSetGroup
+    /// </summary>
+    public interface IExcelConditionalFormattingIconSetGroup<T>
+        : IExcelConditionalFormattingRule
+    {
+        #region Public Properties
     /// <summary>
     /// Reverse
     /// </summary>
@@ -59,5 +59,5 @@ namespace OfficeOpenXml.ConditionalFormatting.Contracts
     /// </summary>
     T IconSet { get; set; }
     #endregion Public Properties
-	}
+    }
 }

--- a/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingRule.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingRule.cs
@@ -37,11 +37,11 @@ using OfficeOpenXml.Style.Dxf;
 
 namespace OfficeOpenXml.ConditionalFormatting.Contracts
 {
-	/// <summary>
-	/// Interface for conditional formatting rule
-	/// </summary>
-	public interface IExcelConditionalFormattingRule
-	{
+    /// <summary>
+    /// Interface for conditional formatting rule
+    /// </summary>
+    public interface IExcelConditionalFormattingRule
+    {
     /// <summary>
     /// The 'cfRule' XML node
     /// </summary>
@@ -59,11 +59,11 @@ namespace OfficeOpenXml.ConditionalFormatting.Contracts
     /// </summary>
     ExcelAddress Address { get; set; }
 
-		/// <summary>
-		/// The priority of this conditional formatting rule. This value is used to determine
-		/// which format should be evaluated and rendered. Lower numeric values are higher
-		/// priority than higher numeric values, where 1 is the highest priority.
-		/// </summary>
+        /// <summary>
+        /// The priority of this conditional formatting rule. This value is used to determine
+        /// which format should be evaluated and rendered. Lower numeric values are higher
+        /// priority than higher numeric values, where 1 is the highest priority.
+        /// </summary>
     int Priority { get; set; }
 
     /// <summary>

--- a/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingStdDevGroup.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingStdDevGroup.cs
@@ -37,14 +37,14 @@ using OfficeOpenXml.ConditionalFormatting;
 
 namespace OfficeOpenXml.ConditionalFormatting.Contracts
 {
-	/// <summary>
+    /// <summary>
   /// IExcelConditionalFormattingStdDevGroup
-	/// </summary>
+    /// </summary>
   public interface IExcelConditionalFormattingStdDevGroup
     : IExcelConditionalFormattingRule,
     IExcelConditionalFormattingWithStdDev
   {
-		#region Public Properties
-		#endregion Public Properties
-	}
+        #region Public Properties
+        #endregion Public Properties
+    }
 }

--- a/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingThreeColorScale.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingThreeColorScale.cs
@@ -37,17 +37,17 @@ using OfficeOpenXml.ConditionalFormatting;
 
 namespace OfficeOpenXml.ConditionalFormatting.Contracts
 {
-	/// <summary>
-	/// IExcelConditionalFormattingThreeColorScale
-	/// </summary>
-	public interface IExcelConditionalFormattingThreeColorScale
+    /// <summary>
+    /// IExcelConditionalFormattingThreeColorScale
+    /// </summary>
+    public interface IExcelConditionalFormattingThreeColorScale
     : IExcelConditionalFormattingTwoColorScale
-	{
-		#region Public Properties
-		/// <summary>
-		/// Three Color Scale Middle Value
-		/// </summary>
-		ExcelConditionalFormattingColorScaleValue MiddleValue { get; set; }
-		#endregion Public Properties
-	}
+    {
+        #region Public Properties
+        /// <summary>
+        /// Three Color Scale Middle Value
+        /// </summary>
+        ExcelConditionalFormattingColorScaleValue MiddleValue { get; set; }
+        #endregion Public Properties
+    }
 }

--- a/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingThreeIconSet.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingThreeIconSet.cs
@@ -37,13 +37,13 @@ using OfficeOpenXml.ConditionalFormatting;
 
 namespace OfficeOpenXml.ConditionalFormatting.Contracts
 {
-	/// <summary>
-	/// IExcelConditionalFormattingThreeIconSet
-	/// </summary>
-	public interface IExcelConditionalFormattingThreeIconSet<T>
+    /// <summary>
+    /// IExcelConditionalFormattingThreeIconSet
+    /// </summary>
+    public interface IExcelConditionalFormattingThreeIconSet<T>
     : IExcelConditionalFormattingIconSetGroup<T>
-	{
-		#region Public Properties
+    {
+        #region Public Properties
     /// <summary>
     /// Icon1 (part of the 3, 4 ou 5 Icon Set)
     /// </summary>
@@ -59,5 +59,5 @@ namespace OfficeOpenXml.ConditionalFormatting.Contracts
     /// </summary>
     ExcelConditionalFormattingIconDataBarValue Icon3 { get; }
     #endregion Public Properties
-	}
+    }
 }

--- a/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingTimePeriodGroup.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingTimePeriodGroup.cs
@@ -37,13 +37,13 @@ using OfficeOpenXml.ConditionalFormatting;
 
 namespace OfficeOpenXml.ConditionalFormatting.Contracts
 {
-	/// <summary>
-	/// IExcelConditionalFormattingTimePeriod
-	/// </summary>
-	public interface IExcelConditionalFormattingTimePeriodGroup
-		: IExcelConditionalFormattingRule
-	{
-		#region Public Properties
-		#endregion Public Properties
-	}
+    /// <summary>
+    /// IExcelConditionalFormattingTimePeriod
+    /// </summary>
+    public interface IExcelConditionalFormattingTimePeriodGroup
+        : IExcelConditionalFormattingRule
+    {
+        #region Public Properties
+        #endregion Public Properties
+    }
 }

--- a/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingTwoColorScale.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IExcelConditionalFormattingTwoColorScale.cs
@@ -37,13 +37,13 @@ using OfficeOpenXml.ConditionalFormatting;
 
 namespace OfficeOpenXml.ConditionalFormatting.Contracts
 {
-	/// <summary>
-	/// IExcelConditionalFormattingTwoColorScale
-	/// </summary>
-	public interface IExcelConditionalFormattingTwoColorScale
-		: IExcelConditionalFormattingColorScaleGroup
-	{
-		#region Public Properties
+    /// <summary>
+    /// IExcelConditionalFormattingTwoColorScale
+    /// </summary>
+    public interface IExcelConditionalFormattingTwoColorScale
+        : IExcelConditionalFormattingColorScaleGroup
+    {
+        #region Public Properties
     /// <summary>
     /// Two Color Scale Low Value
     /// </summary>
@@ -54,5 +54,5 @@ namespace OfficeOpenXml.ConditionalFormatting.Contracts
     /// </summary>
     ExcelConditionalFormattingColorScaleValue HighValue { get; set; }
     #endregion Public Properties
-	}
+    }
 }

--- a/EPPlus/ConditionalFormatting/Contracts/IRangeConditionalFormatting.cs
+++ b/EPPlus/ConditionalFormatting/Contracts/IRangeConditionalFormatting.cs
@@ -33,12 +33,12 @@ using System.Drawing;
 
 namespace OfficeOpenXml.ConditionalFormatting
 {
-	/// <summary>
-	/// Provides functionality for adding Conditional Formatting to a range (<see cref="ExcelRangeBase"/>).
-	/// Each method will return a configurable condtional formatting type.
-	/// </summary>
-	public interface IRangeConditionalFormatting
-	{
+    /// <summary>
+    /// Provides functionality for adding Conditional Formatting to a range (<see cref="ExcelRangeBase"/>).
+    /// Each method will return a configurable condtional formatting type.
+    /// </summary>
+    public interface IRangeConditionalFormatting
+    {
     /// <summary>
     /// Adds a Above Average rule to the range
     /// </summary>

--- a/EPPlus/ConditionalFormatting/ExcelConditionalFormattingColorScaleValue.cs
+++ b/EPPlus/ConditionalFormatting/ExcelConditionalFormattingColorScaleValue.cs
@@ -41,24 +41,24 @@ using System.Security;
 
 namespace OfficeOpenXml.ConditionalFormatting
 {
-	/// <summary>
-	/// 18.3.1.11 cfvo (Conditional Format Value Object)
-	/// Describes the values of the interpolation points in a gradient scale.
-	/// </summary>
-	public class ExcelConditionalFormattingColorScaleValue
-		: XmlHelper
-	{
-		/****************************************************************************************/
+    /// <summary>
+    /// 18.3.1.11 cfvo (Conditional Format Value Object)
+    /// Describes the values of the interpolation points in a gradient scale.
+    /// </summary>
+    public class ExcelConditionalFormattingColorScaleValue
+        : XmlHelper
+    {
+        /****************************************************************************************/
 
-		#region Private Properties
-		private eExcelConditionalFormattingValueObjectPosition _position;
-		private eExcelConditionalFormattingRuleType _ruleType;
-		private ExcelWorksheet _worksheet;
-		#endregion Private Properties
+        #region Private Properties
+        private eExcelConditionalFormattingValueObjectPosition _position;
+        private eExcelConditionalFormattingRuleType _ruleType;
+        private ExcelWorksheet _worksheet;
+        #endregion Private Properties
 
-		/****************************************************************************************/
+        /****************************************************************************************/
 
-		#region Constructors
+        #region Constructors
     /// <summary>
     /// Initialize the cfvo (§18.3.1.11) node
     /// </summary>
@@ -74,237 +74,237 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <param name="itemElementNode">The cfvo (§18.3.1.11) node parent. Can be any of the following:
     /// colorScale (§18.3.1.16); dataBar (§18.3.1.28); iconSet (§18.3.1.49)</param>
     /// <param name="namespaceManager"></param>
-		internal ExcelConditionalFormattingColorScaleValue(
-			eExcelConditionalFormattingValueObjectPosition position,
-			eExcelConditionalFormattingValueObjectType type,
-			Color color,
-			double value,
-			string formula,
-			eExcelConditionalFormattingRuleType ruleType,
+        internal ExcelConditionalFormattingColorScaleValue(
+            eExcelConditionalFormattingValueObjectPosition position,
+            eExcelConditionalFormattingValueObjectType type,
+            Color color,
+            double value,
+            string formula,
+            eExcelConditionalFormattingRuleType ruleType,
       ExcelAddress address,
       int priority,
-			ExcelWorksheet worksheet,
-			XmlNode itemElementNode,
-			XmlNamespaceManager namespaceManager)
-			: base(
-				namespaceManager,
-				itemElementNode)
-		{
-			Require.Argument(priority).IsInRange(1, int.MaxValue, "priority");
-			Require.Argument(address).IsNotNull("address");
-			Require.Argument(worksheet).IsNotNull("worksheet");
+            ExcelWorksheet worksheet,
+            XmlNode itemElementNode,
+            XmlNamespaceManager namespaceManager)
+            : base(
+                namespaceManager,
+                itemElementNode)
+        {
+            Require.Argument(priority).IsInRange(1, int.MaxValue, "priority");
+            Require.Argument(address).IsNotNull("address");
+            Require.Argument(worksheet).IsNotNull("worksheet");
 
-			// Save the worksheet for private methods to use
-			_worksheet = worksheet;
+            // Save the worksheet for private methods to use
+            _worksheet = worksheet;
 
-			// Schema order list
-			SchemaNodeOrder = new string[]
-			{
+            // Schema order list
+            SchemaNodeOrder = new string[]
+            {
         ExcelConditionalFormattingConstants.Nodes.Cfvo,
         ExcelConditionalFormattingConstants.Nodes.Color
-			};
+            };
 
-			// Check if the parent does not exists
-			if (itemElementNode == null)
-			{
-				// Get the parent node path by the rule type
-				string parentNodePath = ExcelConditionalFormattingValueObjectType.GetParentPathByRuleType(
-					ruleType);
+            // Check if the parent does not exists
+            if (itemElementNode == null)
+            {
+                // Get the parent node path by the rule type
+                string parentNodePath = ExcelConditionalFormattingValueObjectType.GetParentPathByRuleType(
+                    ruleType);
 
-				// Check for en error (rule type does not have <cfvo>)
-				if (parentNodePath == string.Empty)
-				{
-					throw new Exception(
-						ExcelConditionalFormattingConstants.Errors.MissingCfvoParentNode);
-				}
+                // Check for en error (rule type does not have <cfvo>)
+                if (parentNodePath == string.Empty)
+                {
+                    throw new Exception(
+                        ExcelConditionalFormattingConstants.Errors.MissingCfvoParentNode);
+                }
 
-				// Point to the <cfvo> parent node
+                // Point to the <cfvo> parent node
         itemElementNode = _worksheet.WorksheetXml.SelectSingleNode(
-					string.Format(
-						"//{0}[{1}='{2}']/{3}[{4}='{5}']/{6}",
-					// {0}
-						ExcelConditionalFormattingConstants.Paths.ConditionalFormatting,
-					// {1}
-						ExcelConditionalFormattingConstants.Paths.SqrefAttribute,
-					// {2}
-						address.Address,
-					// {3}
-						ExcelConditionalFormattingConstants.Paths.CfRule,
-					// {4}
-						ExcelConditionalFormattingConstants.Paths.PriorityAttribute,
-					// {5}
-						priority,
-					// {6}
-						parentNodePath),
-					_worksheet.NameSpaceManager);
+                    string.Format(
+                        "//{0}[{1}='{2}']/{3}[{4}='{5}']/{6}",
+                    // {0}
+                        ExcelConditionalFormattingConstants.Paths.ConditionalFormatting,
+                    // {1}
+                        ExcelConditionalFormattingConstants.Paths.SqrefAttribute,
+                    // {2}
+                        address.Address,
+                    // {3}
+                        ExcelConditionalFormattingConstants.Paths.CfRule,
+                    // {4}
+                        ExcelConditionalFormattingConstants.Paths.PriorityAttribute,
+                    // {5}
+                        priority,
+                    // {6}
+                        parentNodePath),
+                    _worksheet.NameSpaceManager);
 
-				// Check for en error (rule type does not have <cfvo>)
+                // Check for en error (rule type does not have <cfvo>)
         if (itemElementNode == null)
-				{
-					throw new Exception(
-						ExcelConditionalFormattingConstants.Errors.MissingCfvoParentNode);
-				}
-			}
+                {
+                    throw new Exception(
+                        ExcelConditionalFormattingConstants.Errors.MissingCfvoParentNode);
+                }
+            }
 
-			// Point to the <cfvo> parent node (<colorScale>, <dataBar> or <iconSet>)
+            // Point to the <cfvo> parent node (<colorScale>, <dataBar> or <iconSet>)
       // This is different than normal, as TopNode does not point to the node itself but to
       // its PARENT. Later, in the CreateNodeByOrdem method the TopNode will be updated.
       TopNode = itemElementNode;
 
-			// Save the attributes
-			Position = position;
-			RuleType = ruleType;
-			Type = type;
-			Color = color;
-			Value = value;
-			Formula = formula;
-		}
+            // Save the attributes
+            Position = position;
+            RuleType = ruleType;
+            Type = type;
+            Color = color;
+            Value = value;
+            Formula = formula;
+        }
 
-		/// <summary>
-		/// Initialize the <see cref="ExcelConditionalFormattingColorScaleValue"/>
-		/// </summary>
-		/// <param name="position"></param>
-		/// <param name="type"></param>
-		/// <param name="color"></param>
-		/// <param name="value"></param>
-		/// <param name="formula"></param>
-		/// <param name="ruleType"></param>
-		/// <param name="priority"></param>
-		/// <param name="address"></param>
-		/// <param name="worksheet"></param>
-		/// <param name="namespaceManager"></param>
-		internal ExcelConditionalFormattingColorScaleValue(
-			eExcelConditionalFormattingValueObjectPosition position,
-			eExcelConditionalFormattingValueObjectType type,
-			Color color,
-			double value,
-			string formula,
-			eExcelConditionalFormattingRuleType ruleType,
+        /// <summary>
+        /// Initialize the <see cref="ExcelConditionalFormattingColorScaleValue"/>
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="type"></param>
+        /// <param name="color"></param>
+        /// <param name="value"></param>
+        /// <param name="formula"></param>
+        /// <param name="ruleType"></param>
+        /// <param name="priority"></param>
+        /// <param name="address"></param>
+        /// <param name="worksheet"></param>
+        /// <param name="namespaceManager"></param>
+        internal ExcelConditionalFormattingColorScaleValue(
+            eExcelConditionalFormattingValueObjectPosition position,
+            eExcelConditionalFormattingValueObjectType type,
+            Color color,
+            double value,
+            string formula,
+            eExcelConditionalFormattingRuleType ruleType,
       ExcelAddress address,
       int priority,
-			ExcelWorksheet worksheet,
-			XmlNamespaceManager namespaceManager)
-			: this(
-				position,
-				type,
-				color,
-				value,
-				formula,
-				ruleType,
+            ExcelWorksheet worksheet,
+            XmlNamespaceManager namespaceManager)
+            : this(
+                position,
+                type,
+                color,
+                value,
+                formula,
+                ruleType,
         address,
         priority,
-				worksheet,
-				null,
-				namespaceManager)
-		{
-		}
+                worksheet,
+                null,
+                namespaceManager)
+        {
+        }
 
-		/// <summary>
-		/// Initialize the <see cref="ExcelConditionalFormattingColorScaleValue"/>
-		/// </summary>
-		/// <param name="position"></param>
-		/// <param name="type"></param>
-		/// <param name="color"></param>
-		/// <param name="ruleType"></param>
-		/// <param name="priority"></param>
-		/// <param name="address"></param>
-		/// <param name="worksheet"></param>
-		/// <param name="namespaceManager"></param>
-		internal ExcelConditionalFormattingColorScaleValue(
-			eExcelConditionalFormattingValueObjectPosition position,
-			eExcelConditionalFormattingValueObjectType type,
-			Color color,
-			eExcelConditionalFormattingRuleType ruleType,
+        /// <summary>
+        /// Initialize the <see cref="ExcelConditionalFormattingColorScaleValue"/>
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="type"></param>
+        /// <param name="color"></param>
+        /// <param name="ruleType"></param>
+        /// <param name="priority"></param>
+        /// <param name="address"></param>
+        /// <param name="worksheet"></param>
+        /// <param name="namespaceManager"></param>
+        internal ExcelConditionalFormattingColorScaleValue(
+            eExcelConditionalFormattingValueObjectPosition position,
+            eExcelConditionalFormattingValueObjectType type,
+            Color color,
+            eExcelConditionalFormattingRuleType ruleType,
       ExcelAddress address,
       int priority,
-			ExcelWorksheet worksheet,
-			XmlNamespaceManager namespaceManager)
-			: this(
-				position,
-				type,
-				color,
-				0,
-				null,
-				ruleType,
+            ExcelWorksheet worksheet,
+            XmlNamespaceManager namespaceManager)
+            : this(
+                position,
+                type,
+                color,
+                0,
+                null,
+                ruleType,
         address,
         priority,
-				worksheet,
-				null,
-				namespaceManager)
-		{
-		}
-		#endregion Constructors
+                worksheet,
+                null,
+                namespaceManager)
+        {
+        }
+        #endregion Constructors
 
-		/****************************************************************************************/
+        /****************************************************************************************/
 
-		#region Methods
-		/// <summary>
-		/// Get the node order (1, 2 ou 3) according to the Position (Low, Middle and High)
-		/// and the Rule Type (TwoColorScale ou ThreeColorScale).
-		/// </summary>
-		/// <returns></returns>
-		private int GetNodeOrder()
-		{
-			return ExcelConditionalFormattingValueObjectType.GetOrderByPosition(
-				Position,
-				RuleType);
-		}
+        #region Methods
+        /// <summary>
+        /// Get the node order (1, 2 ou 3) according to the Position (Low, Middle and High)
+        /// and the Rule Type (TwoColorScale ou ThreeColorScale).
+        /// </summary>
+        /// <returns></returns>
+        private int GetNodeOrder()
+        {
+            return ExcelConditionalFormattingValueObjectType.GetOrderByPosition(
+                Position,
+                RuleType);
+        }
 
-		/// <summary>
-		/// Create the 'cfvo'/'color' nodes in the right order. They should appear like this:
-		///		"cfvo"   --> Low Value (value object)
-		///		"cfvo"   --> Middle Value (value object)
-		///		"cfvo"   --> High Value (value object)
-		///		"color"  --> Low Value (color)
-		///		"color"  --> Middle Value (color)
-		///		"color"  --> High Value (color)
-		/// </summary>
-		/// <param name="nodeType"></param>
-		/// <param name="attributePath"></param>
-		/// <param name="attributeValue"></param>
-		private void CreateNodeByOrdem(
-			eExcelConditionalFormattingValueObjectNodeType nodeType,
-			string attributePath,
-			string attributeValue)
-		{
+        /// <summary>
+        /// Create the 'cfvo'/'color' nodes in the right order. They should appear like this:
+        ///		"cfvo"   --> Low Value (value object)
+        ///		"cfvo"   --> Middle Value (value object)
+        ///		"cfvo"   --> High Value (value object)
+        ///		"color"  --> Low Value (color)
+        ///		"color"  --> Middle Value (color)
+        ///		"color"  --> High Value (color)
+        /// </summary>
+        /// <param name="nodeType"></param>
+        /// <param name="attributePath"></param>
+        /// <param name="attributeValue"></param>
+        private void CreateNodeByOrdem(
+            eExcelConditionalFormattingValueObjectNodeType nodeType,
+            string attributePath,
+            string attributeValue)
+        {
       // Save the current TopNode
       XmlNode currentTopNode = TopNode;
 
       string nodePath = ExcelConditionalFormattingValueObjectType.GetNodePathByNodeType(nodeType);
-			int nodeOrder = GetNodeOrder();
-			eNodeInsertOrder nodeInsertOrder = eNodeInsertOrder.SchemaOrder;
-			XmlNode referenceNode = null;
+            int nodeOrder = GetNodeOrder();
+            eNodeInsertOrder nodeInsertOrder = eNodeInsertOrder.SchemaOrder;
+            XmlNode referenceNode = null;
 
-			if (nodeOrder > 1)
-			{
-				// Find the node just before the one we need to include
-				referenceNode = TopNode.SelectSingleNode(
-					string.Format(
-						"{0}[position()={1}]",
-					// {0}
-						nodePath,
-					// {1}
-						nodeOrder - 1),
-					_worksheet.NameSpaceManager);
+            if (nodeOrder > 1)
+            {
+                // Find the node just before the one we need to include
+                referenceNode = TopNode.SelectSingleNode(
+                    string.Format(
+                        "{0}[position()={1}]",
+                    // {0}
+                        nodePath,
+                    // {1}
+                        nodeOrder - 1),
+                    _worksheet.NameSpaceManager);
 
-				// Only if the prepend node exists than insert after
-				if (referenceNode != null)
-				{
-					nodeInsertOrder = eNodeInsertOrder.After;
-				}
-			}
+                // Only if the prepend node exists than insert after
+                if (referenceNode != null)
+                {
+                    nodeInsertOrder = eNodeInsertOrder.After;
+                }
+            }
 
-			// Create the node in the right order
-			var node = CreateComplexNode(
-				TopNode,
-				string.Format(
-					"{0}[position()={1}]",
-				// {0}
-					nodePath,
-				// {1}
-					nodeOrder),
-				nodeInsertOrder,
-				referenceNode);
+            // Create the node in the right order
+            var node = CreateComplexNode(
+                TopNode,
+                string.Format(
+                    "{0}[position()={1}]",
+                // {0}
+                    nodePath,
+                // {1}
+                    nodeOrder),
+                nodeInsertOrder,
+                referenceNode);
 
       // Point to the new node as the temporary TopNode (we need it for the XmlHelper functions)
       TopNode = node;
@@ -318,194 +318,194 @@ namespace OfficeOpenXml.ConditionalFormatting
 
       // Point back to the <cfvo>/<color> parent node
       TopNode = currentTopNode;
-		}
-		#endregion Methos
+        }
+        #endregion Methos
 
-		/****************************************************************************************/
+        /****************************************************************************************/
 
-		#region Exposed Properties
-		/// <summary>
-		/// 
-		/// </summary>
-		internal eExcelConditionalFormattingValueObjectPosition Position
-		{
-			get { return _position; }
-			set { _position = value; }
-		}
+        #region Exposed Properties
+        /// <summary>
+        /// 
+        /// </summary>
+        internal eExcelConditionalFormattingValueObjectPosition Position
+        {
+            get { return _position; }
+            set { _position = value; }
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		internal eExcelConditionalFormattingRuleType RuleType
-		{
-			get { return _ruleType; }
-			set { _ruleType = value; }
-		}
+        /// <summary>
+        /// 
+        /// </summary>
+        internal eExcelConditionalFormattingRuleType RuleType
+        {
+            get { return _ruleType; }
+            set { _ruleType = value; }
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public eExcelConditionalFormattingValueObjectType Type
-		{
-			get
-			{
-				var typeAttribute = GetXmlNodeString(
-					string.Format(
-						"{0}[position()={1}]/{2}",
-					// {0}
-						ExcelConditionalFormattingConstants.Paths.Cfvo,
-					// {1}
-						GetNodeOrder(),
-					// {2}
-						ExcelConditionalFormattingConstants.Paths.TypeAttribute));
+        /// <summary>
+        /// 
+        /// </summary>
+        public eExcelConditionalFormattingValueObjectType Type
+        {
+            get
+            {
+                var typeAttribute = GetXmlNodeString(
+                    string.Format(
+                        "{0}[position()={1}]/{2}",
+                    // {0}
+                        ExcelConditionalFormattingConstants.Paths.Cfvo,
+                    // {1}
+                        GetNodeOrder(),
+                    // {2}
+                        ExcelConditionalFormattingConstants.Paths.TypeAttribute));
 
-				return ExcelConditionalFormattingValueObjectType.GetTypeByAttrbiute(typeAttribute);
-			}
-			set
-			{
-				CreateNodeByOrdem(
-					eExcelConditionalFormattingValueObjectNodeType.Cfvo,
-					ExcelConditionalFormattingConstants.Paths.TypeAttribute,
-					ExcelConditionalFormattingValueObjectType.GetAttributeByType(value));
+                return ExcelConditionalFormattingValueObjectType.GetTypeByAttrbiute(typeAttribute);
+            }
+            set
+            {
+                CreateNodeByOrdem(
+                    eExcelConditionalFormattingValueObjectNodeType.Cfvo,
+                    ExcelConditionalFormattingConstants.Paths.TypeAttribute,
+                    ExcelConditionalFormattingValueObjectType.GetAttributeByType(value));
 
-				bool removeValAttribute = false;
+                bool removeValAttribute = false;
 
-				// Make sure unnecessary attributes are removed (occures when we change
-				// the value object type)
-				switch (Type)
-				{
-					case eExcelConditionalFormattingValueObjectType.Min:
-					case eExcelConditionalFormattingValueObjectType.Max:
-						removeValAttribute = true;
-						break;
-				}
+                // Make sure unnecessary attributes are removed (occures when we change
+                // the value object type)
+                switch (Type)
+                {
+                    case eExcelConditionalFormattingValueObjectType.Min:
+                    case eExcelConditionalFormattingValueObjectType.Max:
+                        removeValAttribute = true;
+                        break;
+                }
 
-				// Check if we need to remove the @val attribute
-				if (removeValAttribute)
-				{
-				  string nodePath = ExcelConditionalFormattingValueObjectType.GetNodePathByNodeType(
-						eExcelConditionalFormattingValueObjectNodeType.Cfvo);
-				  int nodeOrder = GetNodeOrder();
+                // Check if we need to remove the @val attribute
+                if (removeValAttribute)
+                {
+                  string nodePath = ExcelConditionalFormattingValueObjectType.GetNodePathByNodeType(
+                        eExcelConditionalFormattingValueObjectNodeType.Cfvo);
+                  int nodeOrder = GetNodeOrder();
 
-					// Remove the attribute (removed when the value = '')
-				  CreateComplexNode(
-				    TopNode,
-				    string.Format(
-				      "{0}[position()={1}]/{2}=''",
-				    // {0}
-				      nodePath,
-				    // {1}
-				      nodeOrder,
-				    // {2}
-				      ExcelConditionalFormattingConstants.Paths.ValAttribute));
-				}
-			}
-		}
+                    // Remove the attribute (removed when the value = '')
+                  CreateComplexNode(
+                    TopNode,
+                    string.Format(
+                      "{0}[position()={1}]/{2}=''",
+                    // {0}
+                      nodePath,
+                    // {1}
+                      nodeOrder,
+                    // {2}
+                      ExcelConditionalFormattingConstants.Paths.ValAttribute));
+                }
+            }
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public Color Color
-		{
-			get
-			{
-				// Color Code like "FF5B34F2"
-				var colorCode = GetXmlNodeString(
-					string.Format(
-						"{0}[position()={1}]/{2}",
-					// {0}
-						ExcelConditionalFormattingConstants.Paths.Color,
-					// {1}
-						GetNodeOrder(),
-					// {2}
-						ExcelConditionalFormattingConstants.Paths.RgbAttribute));
+        /// <summary>
+        /// 
+        /// </summary>
+        public Color Color
+        {
+            get
+            {
+                // Color Code like "FF5B34F2"
+                var colorCode = GetXmlNodeString(
+                    string.Format(
+                        "{0}[position()={1}]/{2}",
+                    // {0}
+                        ExcelConditionalFormattingConstants.Paths.Color,
+                    // {1}
+                        GetNodeOrder(),
+                    // {2}
+                        ExcelConditionalFormattingConstants.Paths.RgbAttribute));
 
-				return ExcelConditionalFormattingHelper.ConvertFromColorCode(colorCode);
-			}
-			set
-			{
-				// Use the color code to store (Ex. "FF5B35F2")
-				CreateNodeByOrdem(
-					eExcelConditionalFormattingValueObjectNodeType.Color,
-					ExcelConditionalFormattingConstants.Paths.RgbAttribute,
-					value.ToArgb().ToString("x"));
-			}
-		}
+                return ExcelConditionalFormattingHelper.ConvertFromColorCode(colorCode);
+            }
+            set
+            {
+                // Use the color code to store (Ex. "FF5B35F2")
+                CreateNodeByOrdem(
+                    eExcelConditionalFormattingValueObjectNodeType.Color,
+                    ExcelConditionalFormattingConstants.Paths.RgbAttribute,
+                    value.ToArgb().ToString("x"));
+            }
+        }
 
-		/// <summary>
-		/// Get/Set the 'cfvo' node @val attribute
-		/// </summary>
-		public Double Value
-		{
-			get
-			{
-				return GetXmlNodeDouble(
-					string.Format(
-						"{0}[position()={1}]/{2}",
-					// {0}
-						ExcelConditionalFormattingConstants.Paths.Cfvo,
-					// {1}
-						GetNodeOrder(),
-					// {2}
-						ExcelConditionalFormattingConstants.Paths.ValAttribute));
-			}
-			set
-			{
-				string valueToStore = string.Empty;
+        /// <summary>
+        /// Get/Set the 'cfvo' node @val attribute
+        /// </summary>
+        public Double Value
+        {
+            get
+            {
+                return GetXmlNodeDouble(
+                    string.Format(
+                        "{0}[position()={1}]/{2}",
+                    // {0}
+                        ExcelConditionalFormattingConstants.Paths.Cfvo,
+                    // {1}
+                        GetNodeOrder(),
+                    // {2}
+                        ExcelConditionalFormattingConstants.Paths.ValAttribute));
+            }
+            set
+            {
+                string valueToStore = string.Empty;
 
-				// Only some types use the @val attribute
-				if ((Type == eExcelConditionalFormattingValueObjectType.Num)
-					|| (Type == eExcelConditionalFormattingValueObjectType.Percent)
-					|| (Type == eExcelConditionalFormattingValueObjectType.Percentile))
-				{
-					valueToStore = value.ToString();
-				}
+                // Only some types use the @val attribute
+                if ((Type == eExcelConditionalFormattingValueObjectType.Num)
+                    || (Type == eExcelConditionalFormattingValueObjectType.Percent)
+                    || (Type == eExcelConditionalFormattingValueObjectType.Percentile))
+                {
+                    valueToStore = value.ToString();
+                }
 
-				CreateNodeByOrdem(
-					eExcelConditionalFormattingValueObjectNodeType.Cfvo,
-					ExcelConditionalFormattingConstants.Paths.ValAttribute,
-					valueToStore);
-			}
-		}
+                CreateNodeByOrdem(
+                    eExcelConditionalFormattingValueObjectNodeType.Cfvo,
+                    ExcelConditionalFormattingConstants.Paths.ValAttribute,
+                    valueToStore);
+            }
+        }
 
-		/// <summary>
-		/// Get/Set the Formula of the Object Value (uses the same attribute as the Value)
-		/// </summary>
-		public string Formula
-		{
-			get
-			{
-				// Return empty if the Object Value type is not Formula
-				if (Type != eExcelConditionalFormattingValueObjectType.Formula)
-				{
-					return string.Empty;
-				}
+        /// <summary>
+        /// Get/Set the Formula of the Object Value (uses the same attribute as the Value)
+        /// </summary>
+        public string Formula
+        {
+            get
+            {
+                // Return empty if the Object Value type is not Formula
+                if (Type != eExcelConditionalFormattingValueObjectType.Formula)
+                {
+                    return string.Empty;
+                }
 
-				// Excel stores the formula in the @val attribute
-				return GetXmlNodeString(
-					string.Format(
-						"{0}[position()={1}]/{2}",
-					// {0}
-						ExcelConditionalFormattingConstants.Paths.Cfvo,
-					// {1}
-						GetNodeOrder(),
-					// {2}
-						ExcelConditionalFormattingConstants.Paths.ValAttribute));
-			}
-			set
-			{
-				// Only store the formula if the Object Value type is Formula
-				if (Type == eExcelConditionalFormattingValueObjectType.Formula)
-				{
-					CreateNodeByOrdem(
-						eExcelConditionalFormattingValueObjectNodeType.Cfvo,
-						ExcelConditionalFormattingConstants.Paths.ValAttribute,
-						(value == null) ? string.Empty : value.ToString());
-				}
-			}
-		}
-		#endregion Exposed Properties
+                // Excel stores the formula in the @val attribute
+                return GetXmlNodeString(
+                    string.Format(
+                        "{0}[position()={1}]/{2}",
+                    // {0}
+                        ExcelConditionalFormattingConstants.Paths.Cfvo,
+                    // {1}
+                        GetNodeOrder(),
+                    // {2}
+                        ExcelConditionalFormattingConstants.Paths.ValAttribute));
+            }
+            set
+            {
+                // Only store the formula if the Object Value type is Formula
+                if (Type == eExcelConditionalFormattingValueObjectType.Formula)
+                {
+                    CreateNodeByOrdem(
+                        eExcelConditionalFormattingValueObjectNodeType.Cfvo,
+                        ExcelConditionalFormattingConstants.Paths.ValAttribute,
+                        (value == null) ? string.Empty : value.ToString());
+                }
+            }
+        }
+        #endregion Exposed Properties
 
-		/****************************************************************************************/
-	}
+        /****************************************************************************************/
+    }
 }

--- a/EPPlus/ConditionalFormatting/ExcelConditionalFormattingIconDatabarValue.cs
+++ b/EPPlus/ConditionalFormatting/ExcelConditionalFormattingIconDatabarValue.cs
@@ -41,23 +41,23 @@ using System.Security;
 
 namespace OfficeOpenXml.ConditionalFormatting
 {
-	/// <summary>
-	/// 18.3.1.11 cfvo (Conditional Format Value Object)
-	/// Describes the values of the interpolation points in a gradient scale.
-	/// </summary>
-	public class ExcelConditionalFormattingIconDataBarValue
-		: XmlHelper
-	{
-		/****************************************************************************************/
+    /// <summary>
+    /// 18.3.1.11 cfvo (Conditional Format Value Object)
+    /// Describes the values of the interpolation points in a gradient scale.
+    /// </summary>
+    public class ExcelConditionalFormattingIconDataBarValue
+        : XmlHelper
+    {
+        /****************************************************************************************/
 
-		#region Private Properties
-		private eExcelConditionalFormattingRuleType _ruleType;
-		private ExcelWorksheet _worksheet;
-		#endregion Private Properties
+        #region Private Properties
+        private eExcelConditionalFormattingRuleType _ruleType;
+        private ExcelWorksheet _worksheet;
+        #endregion Private Properties
 
-		/****************************************************************************************/
+        /****************************************************************************************/
 
-		#region Constructors
+        #region Constructors
     /// <summary>
     /// Initialize the cfvo (§18.3.1.11) node
     /// </summary>
@@ -71,75 +71,75 @@ namespace OfficeOpenXml.ConditionalFormatting
     /// <param name="itemElementNode">The cfvo (§18.3.1.11) node parent. Can be any of the following:
     /// colorScale (§18.3.1.16); dataBar (§18.3.1.28); iconSet (§18.3.1.49)</param>
     /// <param name="namespaceManager"></param>
-		internal ExcelConditionalFormattingIconDataBarValue(
-			eExcelConditionalFormattingValueObjectType type,
-			double value,
-			string formula,
-			eExcelConditionalFormattingRuleType ruleType,
+        internal ExcelConditionalFormattingIconDataBarValue(
+            eExcelConditionalFormattingValueObjectType type,
+            double value,
+            string formula,
+            eExcelConditionalFormattingRuleType ruleType,
             ExcelAddress address,
             int priority,
-			ExcelWorksheet worksheet,
-			XmlNode itemElementNode,
-			XmlNamespaceManager namespaceManager)
-			: this(
+            ExcelWorksheet worksheet,
+            XmlNode itemElementNode,
+            XmlNamespaceManager namespaceManager)
+            : this(
             ruleType,
             address,
             worksheet,
             itemElementNode,
-			namespaceManager)
-		{
-			Require.Argument(priority).IsInRange(1, int.MaxValue, "priority");
+            namespaceManager)
+        {
+            Require.Argument(priority).IsInRange(1, int.MaxValue, "priority");
 
             // Check if the parent does not exists
-			if (itemElementNode == null)
-			{
-				// Get the parent node path by the rule type
-				string parentNodePath = ExcelConditionalFormattingValueObjectType.GetParentPathByRuleType(
-					ruleType);
+            if (itemElementNode == null)
+            {
+                // Get the parent node path by the rule type
+                string parentNodePath = ExcelConditionalFormattingValueObjectType.GetParentPathByRuleType(
+                    ruleType);
 
-				// Check for en error (rule type does not have <cfvo>)
-				if (parentNodePath == string.Empty)
-				{
-					throw new Exception(
-						ExcelConditionalFormattingConstants.Errors.MissingCfvoParentNode);
-				}
+                // Check for en error (rule type does not have <cfvo>)
+                if (parentNodePath == string.Empty)
+                {
+                    throw new Exception(
+                        ExcelConditionalFormattingConstants.Errors.MissingCfvoParentNode);
+                }
 
-				// Point to the <cfvo> parent node
+                // Point to the <cfvo> parent node
         itemElementNode = _worksheet.WorksheetXml.SelectSingleNode(
-					string.Format(
-						"//{0}[{1}='{2}']/{3}[{4}='{5}']/{6}",
-					// {0}
-						ExcelConditionalFormattingConstants.Paths.ConditionalFormatting,
-					// {1}
-						ExcelConditionalFormattingConstants.Paths.SqrefAttribute,
-					// {2}
-						address.Address,
-					// {3}
-						ExcelConditionalFormattingConstants.Paths.CfRule,
-					// {4}
-						ExcelConditionalFormattingConstants.Paths.PriorityAttribute,
-					// {5}
-						priority,
-					// {6}
-						parentNodePath),
-					_worksheet.NameSpaceManager);
+                    string.Format(
+                        "//{0}[{1}='{2}']/{3}[{4}='{5}']/{6}",
+                    // {0}
+                        ExcelConditionalFormattingConstants.Paths.ConditionalFormatting,
+                    // {1}
+                        ExcelConditionalFormattingConstants.Paths.SqrefAttribute,
+                    // {2}
+                        address.Address,
+                    // {3}
+                        ExcelConditionalFormattingConstants.Paths.CfRule,
+                    // {4}
+                        ExcelConditionalFormattingConstants.Paths.PriorityAttribute,
+                    // {5}
+                        priority,
+                    // {6}
+                        parentNodePath),
+                    _worksheet.NameSpaceManager);
 
-				// Check for en error (rule type does not have <cfvo>)
+                // Check for en error (rule type does not have <cfvo>)
                 if (itemElementNode == null)
-				{
-					throw new Exception(
-						ExcelConditionalFormattingConstants.Errors.MissingCfvoParentNode);
-				}
-			}
+                {
+                    throw new Exception(
+                        ExcelConditionalFormattingConstants.Errors.MissingCfvoParentNode);
+                }
+            }
 
             TopNode = itemElementNode;
 
-			// Save the attributes
-			RuleType = ruleType;
-			Type = type;
-			Value = value;
-			Formula = formula;
-		}
+            // Save the attributes
+            RuleType = ruleType;
+            Type = type;
+            Value = value;
+            Formula = formula;
+        }
     /// <summary>
     /// Initialize the cfvo (§18.3.1.11) node
     /// </summary>
@@ -167,9 +167,9 @@ namespace OfficeOpenXml.ConditionalFormatting
 
             // Schema order list
             SchemaNodeOrder = new string[]
-			{
+            {
                 ExcelConditionalFormattingConstants.Nodes.Cfvo,
-			};
+            };
 
             //Check if the parent does not exists
             if (itemElementNode == null)
@@ -187,110 +187,110 @@ namespace OfficeOpenXml.ConditionalFormatting
             }
             RuleType = ruleType;            
         }
-		/// <summary>
-		/// Initialize the <see cref="ExcelConditionalFormattingColorScaleValue"/>
-		/// </summary>
-		/// <param name="type"></param>
-		/// <param name="value"></param>
-		/// <param name="formula"></param>
-		/// <param name="ruleType"></param>
-		/// <param name="priority"></param>
-		/// <param name="address"></param>
-		/// <param name="worksheet"></param>
-		/// <param name="namespaceManager"></param>
-		internal ExcelConditionalFormattingIconDataBarValue(
-			eExcelConditionalFormattingValueObjectType type,
-			double value,
-			string formula,
-			eExcelConditionalFormattingRuleType ruleType,
+        /// <summary>
+        /// Initialize the <see cref="ExcelConditionalFormattingColorScaleValue"/>
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="value"></param>
+        /// <param name="formula"></param>
+        /// <param name="ruleType"></param>
+        /// <param name="priority"></param>
+        /// <param name="address"></param>
+        /// <param name="worksheet"></param>
+        /// <param name="namespaceManager"></param>
+        internal ExcelConditionalFormattingIconDataBarValue(
+            eExcelConditionalFormattingValueObjectType type,
+            double value,
+            string formula,
+            eExcelConditionalFormattingRuleType ruleType,
             ExcelAddress address,
             int priority,
-			ExcelWorksheet worksheet,
-			XmlNamespaceManager namespaceManager)
-			: this(
-				type,
-				value,
-				formula,
-				ruleType,
+            ExcelWorksheet worksheet,
+            XmlNamespaceManager namespaceManager)
+            : this(
+                type,
+                value,
+                formula,
+                ruleType,
                 address,
                 priority,
-				worksheet,
-				null,
-				namespaceManager)
-		{
+                worksheet,
+                null,
+                namespaceManager)
+        {
             
-		}
-		/// <summary>
-		/// Initialize the <see cref="ExcelConditionalFormattingColorScaleValue"/>
-		/// </summary>
-		/// <param name="type"></param>
-		/// <param name="color"></param>
-		/// <param name="ruleType"></param>
-		/// <param name="priority"></param>
-		/// <param name="address"></param>
-		/// <param name="worksheet"></param>
-		/// <param name="namespaceManager"></param>
-		internal ExcelConditionalFormattingIconDataBarValue(
-			eExcelConditionalFormattingValueObjectType type,
-			Color color,
-			eExcelConditionalFormattingRuleType ruleType,
+        }
+        /// <summary>
+        /// Initialize the <see cref="ExcelConditionalFormattingColorScaleValue"/>
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="color"></param>
+        /// <param name="ruleType"></param>
+        /// <param name="priority"></param>
+        /// <param name="address"></param>
+        /// <param name="worksheet"></param>
+        /// <param name="namespaceManager"></param>
+        internal ExcelConditionalFormattingIconDataBarValue(
+            eExcelConditionalFormattingValueObjectType type,
+            Color color,
+            eExcelConditionalFormattingRuleType ruleType,
             ExcelAddress address,
             int priority,
-			ExcelWorksheet worksheet,
-			XmlNamespaceManager namespaceManager)
-			: this(
-				type,
-				0,
-				null,
-				ruleType,
+            ExcelWorksheet worksheet,
+            XmlNamespaceManager namespaceManager)
+            : this(
+                type,
+                0,
+                null,
+                ruleType,
                 address,
                 priority,
-				worksheet,
-				null,
-				namespaceManager)
-		{
-		}
-		#endregion Constructors
+                worksheet,
+                null,
+                namespaceManager)
+        {
+        }
+        #endregion Constructors
 
-		/****************************************************************************************/
+        /****************************************************************************************/
 
-		#region Methods
+        #region Methods
         #endregion
 
         /****************************************************************************************/
 
-		#region Exposed Properties
+        #region Exposed Properties
 
-		/// <summary>
-		/// 
-		/// </summary>
-		internal eExcelConditionalFormattingRuleType RuleType
-		{
-			get { return _ruleType; }
-			set { _ruleType = value; }
-		}
+        /// <summary>
+        /// 
+        /// </summary>
+        internal eExcelConditionalFormattingRuleType RuleType
+        {
+            get { return _ruleType; }
+            set { _ruleType = value; }
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public eExcelConditionalFormattingValueObjectType Type
-		{
-			get
-			{
-				var typeAttribute = GetXmlNodeString(ExcelConditionalFormattingConstants.Paths.TypeAttribute);
+        /// <summary>
+        /// 
+        /// </summary>
+        public eExcelConditionalFormattingValueObjectType Type
+        {
+            get
+            {
+                var typeAttribute = GetXmlNodeString(ExcelConditionalFormattingConstants.Paths.TypeAttribute);
 
-				return ExcelConditionalFormattingValueObjectType.GetTypeByAttrbiute(typeAttribute);
-			}
-			set
-			{
+                return ExcelConditionalFormattingValueObjectType.GetTypeByAttrbiute(typeAttribute);
+            }
+            set
+            {
                 if ((_ruleType==eExcelConditionalFormattingRuleType.ThreeIconSet || _ruleType==eExcelConditionalFormattingRuleType.FourIconSet || _ruleType==eExcelConditionalFormattingRuleType.FiveIconSet) &&
                     (value == eExcelConditionalFormattingValueObjectType.Min || value == eExcelConditionalFormattingValueObjectType.Max))
                 {
                     throw(new ArgumentException("Value type can't be Min or Max for icon sets"));
                 }
                 SetXmlNodeString(ExcelConditionalFormattingConstants.Paths.TypeAttribute, value.ToString().ToLower(CultureInfo.InvariantCulture));                
-			}
-		}
+            }
+        }
 
         /// <summary>
         /// Get/Set the 'cfvo' node @gte attribute
@@ -317,9 +317,9 @@ namespace OfficeOpenXml.ConditionalFormatting
         /// Get/Set the 'cfvo' node @val attribute
         /// </summary>
         public Double Value
-		{
-			get
-			{
+        {
+            get
+            {
                 if ((Type == eExcelConditionalFormattingValueObjectType.Num)
                     || (Type == eExcelConditionalFormattingValueObjectType.Percent)
                     || (Type == eExcelConditionalFormattingValueObjectType.Percentile))
@@ -331,49 +331,49 @@ namespace OfficeOpenXml.ConditionalFormatting
                     return 0;
                 }
             }
-			set
-			{
-				string valueToStore = string.Empty;
+            set
+            {
+                string valueToStore = string.Empty;
 
-				// Only some types use the @val attribute
-				if ((Type == eExcelConditionalFormattingValueObjectType.Num)
-					|| (Type == eExcelConditionalFormattingValueObjectType.Percent)
-					|| (Type == eExcelConditionalFormattingValueObjectType.Percentile))
-				{
-					valueToStore = value.ToString(CultureInfo.InvariantCulture);
-				}
+                // Only some types use the @val attribute
+                if ((Type == eExcelConditionalFormattingValueObjectType.Num)
+                    || (Type == eExcelConditionalFormattingValueObjectType.Percent)
+                    || (Type == eExcelConditionalFormattingValueObjectType.Percentile))
+                {
+                    valueToStore = value.ToString(CultureInfo.InvariantCulture);
+                }
 
                 SetXmlNodeString(ExcelConditionalFormattingConstants.Paths.ValAttribute, valueToStore);
-			}
-		}
+            }
+        }
 
-		/// <summary>
-		/// Get/Set the Formula of the Object Value (uses the same attribute as the Value)
-		/// </summary>
-		public string Formula
-		{
-			get
-			{
-				// Return empty if the Object Value type is not Formula
-				if (Type != eExcelConditionalFormattingValueObjectType.Formula)
-				{
-					return string.Empty;
-				}
+        /// <summary>
+        /// Get/Set the Formula of the Object Value (uses the same attribute as the Value)
+        /// </summary>
+        public string Formula
+        {
+            get
+            {
+                // Return empty if the Object Value type is not Formula
+                if (Type != eExcelConditionalFormattingValueObjectType.Formula)
+                {
+                    return string.Empty;
+                }
 
-				// Excel stores the formula in the @val attribute
-				return GetXmlNodeString(ExcelConditionalFormattingConstants.Paths.ValAttribute);
-			}
-			set
-			{
-				// Only store the formula if the Object Value type is Formula
-				if (Type == eExcelConditionalFormattingValueObjectType.Formula)
-				{
+                // Excel stores the formula in the @val attribute
+                return GetXmlNodeString(ExcelConditionalFormattingConstants.Paths.ValAttribute);
+            }
+            set
+            {
+                // Only store the formula if the Object Value type is Formula
+                if (Type == eExcelConditionalFormattingValueObjectType.Formula)
+                {
                     SetXmlNodeString(ExcelConditionalFormattingConstants.Paths.ValAttribute, value);
-				}
-			}
-		}
-		#endregion Exposed Properties
+                }
+            }
+        }
+        #endregion Exposed Properties
 
-		/****************************************************************************************/
-	}
+        /****************************************************************************************/
+    }
 }

--- a/EPPlus/ConditionalFormatting/ExcelConditionalFormattingOperatorType.cs
+++ b/EPPlus/ConditionalFormatting/ExcelConditionalFormattingOperatorType.cs
@@ -36,21 +36,21 @@ using System.Xml;
 
 namespace OfficeOpenXml.ConditionalFormatting
 {
-	/// <summary>
+    /// <summary>
   /// Functions related to the <see cref="ExcelConditionalFormattingOperatorType"/>
-	/// </summary>
+    /// </summary>
   internal static class ExcelConditionalFormattingOperatorType
-	{
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="type"></param>
-		/// <returns></returns>
-		internal static string GetAttributeByType(
-			eExcelConditionalFormattingOperatorType type)
-		{
-			switch (type)
-			{
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        internal static string GetAttributeByType(
+            eExcelConditionalFormattingOperatorType type)
+        {
+            switch (type)
+            {
         case eExcelConditionalFormattingOperatorType.BeginsWith:
           return ExcelConditionalFormattingConstants.Operators.BeginsWith;
 
@@ -86,10 +86,10 @@ namespace OfficeOpenXml.ConditionalFormatting
 
         case eExcelConditionalFormattingOperatorType.NotEqual:
           return ExcelConditionalFormattingConstants.Operators.NotEqual;
-			}
+            }
 
-			return string.Empty;
-		}
+            return string.Empty;
+        }
 
     /// <summary>
     /// 

--- a/EPPlus/ConditionalFormatting/ExcelConditionalFormattingRuleFactory.cs
+++ b/EPPlus/ConditionalFormatting/ExcelConditionalFormattingRuleFactory.cs
@@ -38,31 +38,31 @@ using OfficeOpenXml.ConditionalFormatting.Contracts;
 
 namespace OfficeOpenXml.ConditionalFormatting
 {
-	/// <summary>
-	/// Factory class for ExcelConditionalFormatting.
-	/// </summary>
-	internal static class ExcelConditionalFormattingRuleFactory
-	{
-		public static ExcelConditionalFormattingRule Create(
-			eExcelConditionalFormattingRuleType type,
+    /// <summary>
+    /// Factory class for ExcelConditionalFormatting.
+    /// </summary>
+    internal static class ExcelConditionalFormattingRuleFactory
+    {
+        public static ExcelConditionalFormattingRule Create(
+            eExcelConditionalFormattingRuleType type,
       ExcelAddress address,
       int priority,
-			ExcelWorksheet worksheet,
-			XmlNode itemElementNode)
-		{
-			Require.Argument(type);
+            ExcelWorksheet worksheet,
+            XmlNode itemElementNode)
+        {
+            Require.Argument(type);
       Require.Argument(address).IsNotNull("address");
 
-	  // While MSDN states that 1 is the "highest priority," it also defines this
-	  // field as W3C XML Schema int, which would allow values less than 1. Excel
-	  // itself will, on occasion, use a value of 0, so this check will allow a 0.
+      // While MSDN states that 1 is the "highest priority," it also defines this
+      // field as W3C XML Schema int, which would allow values less than 1. Excel
+      // itself will, on occasion, use a value of 0, so this check will allow a 0.
       Require.Argument(priority).IsInRange(0, int.MaxValue, "priority");
 
       Require.Argument(worksheet).IsNotNull("worksheet");
-			
-			// According the conditional formatting rule type
-			switch (type)
-			{
+            
+            // According the conditional formatting rule type
+            switch (type)
+            {
         case eExcelConditionalFormattingRuleType.AboveAverage:
           return new ExcelConditionalFormattingAboveAverage(
             address,
@@ -348,8 +348,8 @@ namespace OfficeOpenXml.ConditionalFormatting
           return new ExcelConditionalFormattingTwoColorScale(
             address,
             priority,
-						worksheet,
-						itemElementNode);
+                        worksheet,
+                        itemElementNode);
         case eExcelConditionalFormattingRuleType.ThreeIconSet:
           return new ExcelConditionalFormattingThreeIconSet(
             address,
@@ -382,12 +382,12 @@ namespace OfficeOpenXml.ConditionalFormatting
 
 
         //TODO: Add DataBar
-			}
+            }
 
-			throw new InvalidOperationException(
+            throw new InvalidOperationException(
         string.Format(
           ExcelConditionalFormattingConstants.Errors.NonSupportedRuleType,
           type.ToString()));
-		}
-	}
+        }
+    }
 }

--- a/EPPlus/ConditionalFormatting/ExcelConditionalFormattingTimePeriodType.cs
+++ b/EPPlus/ConditionalFormatting/ExcelConditionalFormattingTimePeriodType.cs
@@ -36,21 +36,21 @@ using System.Xml;
 
 namespace OfficeOpenXml.ConditionalFormatting
 {
-	/// <summary>
+    /// <summary>
   /// Functions related to the <see cref="ExcelConditionalFormattingTimePeriodType"/>
-	/// </summary>
+    /// </summary>
   internal static class ExcelConditionalFormattingTimePeriodType
-	{
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="type"></param>
-		/// <returns></returns>
-		public static string GetAttributeByType(
-			eExcelConditionalFormattingTimePeriodType type)
-		{
-			switch (type)
-			{
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static string GetAttributeByType(
+            eExcelConditionalFormattingTimePeriodType type)
+        {
+            switch (type)
+            {
         case eExcelConditionalFormattingTimePeriodType.Last7Days:
           return ExcelConditionalFormattingConstants.TimePeriods.Last7Days;
 
@@ -80,10 +80,10 @@ namespace OfficeOpenXml.ConditionalFormatting
 
         case eExcelConditionalFormattingTimePeriodType.Yesterday:
           return ExcelConditionalFormattingConstants.TimePeriods.Yesterday;
-			}
+            }
 
-			return string.Empty;
-		}
+            return string.Empty;
+        }
 
     /// <summary>
     /// 

--- a/EPPlus/ConditionalFormatting/ExcelConditionalFormattingValueObjectType.cs
+++ b/EPPlus/ConditionalFormatting/ExcelConditionalFormattingValueObjectType.cs
@@ -36,187 +36,187 @@ using System.Xml;
 
 namespace OfficeOpenXml.ConditionalFormatting
 {
-	/// <summary>
-	/// Functions related to the <see cref="ExcelConditionalFormattingColorScaleValue"/>
-	/// </summary>
-	internal static class ExcelConditionalFormattingValueObjectType
-	{
-		/// <summary>
-		/// Get the sequencial order of a cfvo/color by its position.
-		/// </summary>
-		/// <param name="position"></param>
+    /// <summary>
+    /// Functions related to the <see cref="ExcelConditionalFormattingColorScaleValue"/>
+    /// </summary>
+    internal static class ExcelConditionalFormattingValueObjectType
+    {
+        /// <summary>
+        /// Get the sequencial order of a cfvo/color by its position.
+        /// </summary>
+        /// <param name="position"></param>
         /// <param name="ruleType"></param>
-		/// <returns>1, 2 or 3</returns>
-		internal static int GetOrderByPosition(
-			eExcelConditionalFormattingValueObjectPosition position,
-			eExcelConditionalFormattingRuleType ruleType)
-		{
-			switch (position)
-			{
-				case eExcelConditionalFormattingValueObjectPosition.Low:
-					return 1;
+        /// <returns>1, 2 or 3</returns>
+        internal static int GetOrderByPosition(
+            eExcelConditionalFormattingValueObjectPosition position,
+            eExcelConditionalFormattingRuleType ruleType)
+        {
+            switch (position)
+            {
+                case eExcelConditionalFormattingValueObjectPosition.Low:
+                    return 1;
 
-				case eExcelConditionalFormattingValueObjectPosition.Middle:
-					return 2;
+                case eExcelConditionalFormattingValueObjectPosition.Middle:
+                    return 2;
 
-				case eExcelConditionalFormattingValueObjectPosition.High:
-					// Check if the rule type is TwoColorScale.
-					if (ruleType == eExcelConditionalFormattingRuleType.TwoColorScale)
-					{
-						// There are only "Low" and "High". So "High" is the second
-						return 2;
-					}
+                case eExcelConditionalFormattingValueObjectPosition.High:
+                    // Check if the rule type is TwoColorScale.
+                    if (ruleType == eExcelConditionalFormattingRuleType.TwoColorScale)
+                    {
+                        // There are only "Low" and "High". So "High" is the second
+                        return 2;
+                    }
 
-					// There are "Low", "Middle" and "High". So "High" is the third
-					return 3;
-			}
+                    // There are "Low", "Middle" and "High". So "High" is the third
+                    return 3;
+            }
 
-			return 0;
-		}
+            return 0;
+        }
 
-		/// <summary>
-		/// Get the CFVO type by its @type attribute
-		/// </summary>
-		/// <param name="attribute"></param>
-		/// <returns></returns>
-		public static eExcelConditionalFormattingValueObjectType GetTypeByAttrbiute(
-			string attribute)
-		{
-			switch (attribute)
-			{
-				case ExcelConditionalFormattingConstants.CfvoType.Min:
-					return eExcelConditionalFormattingValueObjectType.Min;
+        /// <summary>
+        /// Get the CFVO type by its @type attribute
+        /// </summary>
+        /// <param name="attribute"></param>
+        /// <returns></returns>
+        public static eExcelConditionalFormattingValueObjectType GetTypeByAttrbiute(
+            string attribute)
+        {
+            switch (attribute)
+            {
+                case ExcelConditionalFormattingConstants.CfvoType.Min:
+                    return eExcelConditionalFormattingValueObjectType.Min;
 
         case ExcelConditionalFormattingConstants.CfvoType.Max:
-					return eExcelConditionalFormattingValueObjectType.Max;
+                    return eExcelConditionalFormattingValueObjectType.Max;
 
         case ExcelConditionalFormattingConstants.CfvoType.Num:
-					return eExcelConditionalFormattingValueObjectType.Num;
+                    return eExcelConditionalFormattingValueObjectType.Num;
 
         case ExcelConditionalFormattingConstants.CfvoType.Formula:
-					return eExcelConditionalFormattingValueObjectType.Formula;
+                    return eExcelConditionalFormattingValueObjectType.Formula;
 
         case ExcelConditionalFormattingConstants.CfvoType.Percent:
-					return eExcelConditionalFormattingValueObjectType.Percent;
+                    return eExcelConditionalFormattingValueObjectType.Percent;
 
         case ExcelConditionalFormattingConstants.CfvoType.Percentile:
-					return eExcelConditionalFormattingValueObjectType.Percentile;
-			}
+                    return eExcelConditionalFormattingValueObjectType.Percentile;
+            }
 
-			throw new Exception(
+            throw new Exception(
         ExcelConditionalFormattingConstants.Errors.UnexistentCfvoTypeAttribute);
-		}
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="position"></param>
-		///<param name="ruleType"></param>
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="position"></param>
+        ///<param name="ruleType"></param>
         /// <param name="topNode"></param>
-		/// <param name="nameSpaceManager"></param>
-		/// <returns></returns>
-		public static XmlNode GetCfvoNodeByPosition(
-			eExcelConditionalFormattingValueObjectPosition position,
-			eExcelConditionalFormattingRuleType ruleType,
-			XmlNode topNode,
-			XmlNamespaceManager nameSpaceManager)
-		{
-			// Get the corresponding <cfvo> node (by the position)
-			var node = topNode.SelectSingleNode(
-				string.Format(
-					"{0}[position()={1}]",
-				// {0}
-					ExcelConditionalFormattingConstants.Paths.Cfvo,
-				// {1}
-					ExcelConditionalFormattingValueObjectType.GetOrderByPosition(position, ruleType)),
-				nameSpaceManager);
+        /// <param name="nameSpaceManager"></param>
+        /// <returns></returns>
+        public static XmlNode GetCfvoNodeByPosition(
+            eExcelConditionalFormattingValueObjectPosition position,
+            eExcelConditionalFormattingRuleType ruleType,
+            XmlNode topNode,
+            XmlNamespaceManager nameSpaceManager)
+        {
+            // Get the corresponding <cfvo> node (by the position)
+            var node = topNode.SelectSingleNode(
+                string.Format(
+                    "{0}[position()={1}]",
+                // {0}
+                    ExcelConditionalFormattingConstants.Paths.Cfvo,
+                // {1}
+                    ExcelConditionalFormattingValueObjectType.GetOrderByPosition(position, ruleType)),
+                nameSpaceManager);
 
-			if (node == null)
-			{
-				throw new Exception(
+            if (node == null)
+            {
+                throw new Exception(
           ExcelConditionalFormattingConstants.Errors.MissingCfvoNode);
-			}
+            }
 
-			return node;
-		}
+            return node;
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="type"></param>
-		/// <returns></returns>
-		public static string GetAttributeByType(
-			eExcelConditionalFormattingValueObjectType type)
-		{
-			switch (type)
-			{
-				case eExcelConditionalFormattingValueObjectType.Min:
-					return ExcelConditionalFormattingConstants.CfvoType.Min;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static string GetAttributeByType(
+            eExcelConditionalFormattingValueObjectType type)
+        {
+            switch (type)
+            {
+                case eExcelConditionalFormattingValueObjectType.Min:
+                    return ExcelConditionalFormattingConstants.CfvoType.Min;
 
-				case eExcelConditionalFormattingValueObjectType.Max:
+                case eExcelConditionalFormattingValueObjectType.Max:
           return ExcelConditionalFormattingConstants.CfvoType.Max;
 
-				case eExcelConditionalFormattingValueObjectType.Num:
+                case eExcelConditionalFormattingValueObjectType.Num:
           return ExcelConditionalFormattingConstants.CfvoType.Num;
 
-				case eExcelConditionalFormattingValueObjectType.Formula:
+                case eExcelConditionalFormattingValueObjectType.Formula:
           return ExcelConditionalFormattingConstants.CfvoType.Formula;
 
-				case eExcelConditionalFormattingValueObjectType.Percent:
+                case eExcelConditionalFormattingValueObjectType.Percent:
           return ExcelConditionalFormattingConstants.CfvoType.Percent;
 
-				case eExcelConditionalFormattingValueObjectType.Percentile:
+                case eExcelConditionalFormattingValueObjectType.Percentile:
           return ExcelConditionalFormattingConstants.CfvoType.Percentile;
-			}
+            }
 
-			return string.Empty;
-		}
+            return string.Empty;
+        }
 
-		/// <summary>
-		/// Get the cfvo (§18.3.1.11) node parent by the rule type. Can be any of the following:
-		/// "colorScale" (§18.3.1.16); "dataBar" (§18.3.1.28); "iconSet" (§18.3.1.49)
-		/// </summary>
-		/// <param name="ruleType"></param>
-		/// <returns></returns>
-		public static string GetParentPathByRuleType(
-			eExcelConditionalFormattingRuleType ruleType)
-		{
-			switch (ruleType)
-			{
-				case eExcelConditionalFormattingRuleType.TwoColorScale:
-				case eExcelConditionalFormattingRuleType.ThreeColorScale:
-					return ExcelConditionalFormattingConstants.Paths.ColorScale;
+        /// <summary>
+        /// Get the cfvo (§18.3.1.11) node parent by the rule type. Can be any of the following:
+        /// "colorScale" (§18.3.1.16); "dataBar" (§18.3.1.28); "iconSet" (§18.3.1.49)
+        /// </summary>
+        /// <param name="ruleType"></param>
+        /// <returns></returns>
+        public static string GetParentPathByRuleType(
+            eExcelConditionalFormattingRuleType ruleType)
+        {
+            switch (ruleType)
+            {
+                case eExcelConditionalFormattingRuleType.TwoColorScale:
+                case eExcelConditionalFormattingRuleType.ThreeColorScale:
+                    return ExcelConditionalFormattingConstants.Paths.ColorScale;
 
-				case eExcelConditionalFormattingRuleType.ThreeIconSet:
+                case eExcelConditionalFormattingRuleType.ThreeIconSet:
                 case eExcelConditionalFormattingRuleType.FourIconSet:
                 case eExcelConditionalFormattingRuleType.FiveIconSet:
-					        return ExcelConditionalFormattingConstants.Paths.IconSet;
+                            return ExcelConditionalFormattingConstants.Paths.IconSet;
 
                 case eExcelConditionalFormattingRuleType.DataBar:
                   return ExcelConditionalFormattingConstants.Paths.DataBar;
               }
 
-			return string.Empty;
-		}
+            return string.Empty;
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="nodeType"></param>
-		/// <returns></returns>
-		public static string GetNodePathByNodeType(
-			eExcelConditionalFormattingValueObjectNodeType nodeType)
-		{
-			switch(nodeType)
-			{
-				case eExcelConditionalFormattingValueObjectNodeType.Cfvo:
-					return ExcelConditionalFormattingConstants.Paths.Cfvo;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="nodeType"></param>
+        /// <returns></returns>
+        public static string GetNodePathByNodeType(
+            eExcelConditionalFormattingValueObjectNodeType nodeType)
+        {
+            switch(nodeType)
+            {
+                case eExcelConditionalFormattingValueObjectNodeType.Cfvo:
+                    return ExcelConditionalFormattingConstants.Paths.Cfvo;
 
-				case eExcelConditionalFormattingValueObjectNodeType.Color:
-					return ExcelConditionalFormattingConstants.Paths.Color;
-			}
+                case eExcelConditionalFormattingValueObjectNodeType.Color:
+                    return ExcelConditionalFormattingConstants.Paths.Color;
+            }
 
-			return string.Empty;
-		}
-	}
+            return string.Empty;
+        }
+    }
 }

--- a/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingRule.cs
+++ b/EPPlus/ConditionalFormatting/Rules/ExcelConditionalFormattingRule.cs
@@ -86,9 +86,9 @@ namespace OfficeOpenXml.ConditionalFormatting
     {
       Require.Argument(address).IsNotNull("address");
 
-  	  // While MSDN states that 1 is the "highest priority," it also defines this
-	  // field as W3C XML Schema int, which would allow values less than 1. Excel
-	  // itself will, on occasion, use a value of 0, so this check will allow a 0.
+        // While MSDN states that 1 is the "highest priority," it also defines this
+      // field as W3C XML Schema int, which would allow values less than 1. Excel
+      // itself will, on occasion, use a value of 0, so this check will allow a 0.
       Require.Argument(priority).IsInRange(0, int.MaxValue, "priority");
 
       Require.Argument(worksheet).IsNotNull("worksheet");

--- a/EPPlus/Drawing/Chart/ExcelChart.cs
+++ b/EPPlus/Drawing/Chart/ExcelChart.cs
@@ -842,7 +842,7 @@ namespace OfficeOpenXml.Drawing.Chart
        }
        private string AddPerspectiveXml(eChartType type)
         {
- 	        //Add for 3D sharts
+             //Add for 3D sharts
             if (IsType3D())
             {
                 return "<c:view3D><c:perspective val=\"30\" /></c:view3D>";

--- a/EPPlus/Drawing/Chart/ExcelSurfaceChart.cs
+++ b/EPPlus/Drawing/Chart/ExcelSurfaceChart.cs
@@ -61,7 +61,7 @@ namespace OfficeOpenXml.Drawing.Chart
         }
         private void Init()
         {
- 	        _floor=new ExcelChartSurface(NameSpaceManager, _chartXmlHelper.TopNode.SelectSingleNode("c:floor", NameSpaceManager));
+             _floor=new ExcelChartSurface(NameSpaceManager, _chartXmlHelper.TopNode.SelectSingleNode("c:floor", NameSpaceManager));
             _backWall = new ExcelChartSurface(NameSpaceManager, _chartXmlHelper.TopNode.SelectSingleNode("c:sideWall", NameSpaceManager));
             _sideWall = new ExcelChartSurface(NameSpaceManager, _chartXmlHelper.TopNode.SelectSingleNode("c:backWall", NameSpaceManager));
             SetTypeProperties();

--- a/EPPlus/Encryption/EncryptionHandler.cs
+++ b/EPPlus/Encryption/EncryptionHandler.cs
@@ -986,7 +986,7 @@ namespace OfficeOpenXml.Encryption
                 throw (new Exception("An error occured when the encryptionkey was created", ex));
             }
         }
-		private byte[] GetFinalHash(HashAlgorithm hashProvider, byte[] blockKey, byte[] hash)
+        private byte[] GetFinalHash(HashAlgorithm hashProvider, byte[] blockKey, byte[] hash)
         {
             //2.3.4.13 MS-OFFCRYPTO
             var tempHash = new byte[hash.Length + blockKey.Length];

--- a/EPPlus/ExcelColumn.cs
+++ b/EPPlus/ExcelColumn.cs
@@ -35,46 +35,46 @@ using OfficeOpenXml.Style;
 namespace OfficeOpenXml
 {
     /// <summary>
-	/// Represents one or more columns within the worksheet
-	/// </summary>
-	public class ExcelColumn : IRangeID
-	{
-		private ExcelWorksheet _worksheet;
-		private XmlElement _colElement = null;
+    /// Represents one or more columns within the worksheet
+    /// </summary>
+    public class ExcelColumn : IRangeID
+    {
+        private ExcelWorksheet _worksheet;
+        private XmlElement _colElement = null;
 
-		#region ExcelColumn Constructor
-		/// <summary>
-		/// Creates a new instance of the ExcelColumn class.  
-		/// For internal use only!
-		/// </summary>
-		/// <param name="Worksheet"></param>
-		/// <param name="col"></param>
-		protected internal ExcelColumn(ExcelWorksheet Worksheet, int col)
+        #region ExcelColumn Constructor
+        /// <summary>
+        /// Creates a new instance of the ExcelColumn class.  
+        /// For internal use only!
+        /// </summary>
+        /// <param name="Worksheet"></param>
+        /// <param name="col"></param>
+        protected internal ExcelColumn(ExcelWorksheet Worksheet, int col)
         {
             _worksheet = Worksheet;
             _columnMin = col;
             _columnMax = col;
             _width = _worksheet.DefaultColWidth;
         }
-		#endregion
+        #endregion
         internal int _columnMin;		
-		/// <summary>
-		/// Sets the first column the definition refers to.
-		/// </summary>
-		public int ColumnMin 
-		{
+        /// <summary>
+        /// Sets the first column the definition refers to.
+        /// </summary>
+        public int ColumnMin 
+        {
             get { return _columnMin; }
-			//set { _columnMin=value; } 
-		}
+            //set { _columnMin=value; } 
+        }
 
         internal int _columnMax;
         /// <summary>
-		/// Sets the last column the definition refers to.
-		/// </summary>
+        /// Sets the last column the definition refers to.
+        /// </summary>
         public int ColumnMax 
-		{ 
+        { 
             get { return _columnMax; }
-			set 
+            set 
             {
                 if (value < _columnMin && value > ExcelPackage.MaxColumns)
                 {
@@ -92,7 +92,7 @@ namespace OfficeOpenXml
                 }
                 _columnMax = value; 
             } 
-		}
+        }
         /// <summary>
         /// Internal range id for the column
         /// </summary>
@@ -103,19 +103,19 @@ namespace OfficeOpenXml
                 return ExcelColumn.GetColumnID(_worksheet.SheetID, ColumnMin);
             }
         }
-		#region ExcelColumn Hidden
-		/// <summary>
-		/// Allows the column to be hidden in the worksheet
-		/// </summary>
+        #region ExcelColumn Hidden
+        /// <summary>
+        /// Allows the column to be hidden in the worksheet
+        /// </summary>
         internal bool _hidden=false;
         public bool Hidden
-		{
-			get
-			{
+        {
+            get
+            {
                 return _hidden;
-			}
-			set
-			{
+            }
+            set
+            {
                 if (_worksheet._package.DoAdjustDrawings)
                 {
                     var pos = _worksheet.Drawings.GetDrawingWidths();
@@ -126,11 +126,11 @@ namespace OfficeOpenXml
                 {
                     _hidden = value;
                 }
-			}
-		}
-		#endregion
+            }
+        }
+        #endregion
 
-		#region ExcelColumn Width
+        #region ExcelColumn Width
         internal double VisualWidth
         {
             get
@@ -150,12 +150,12 @@ namespace OfficeOpenXml
         /// Sets the width of the column in the worksheet
         /// </summary>
         public double Width
-		{
-			get
-			{
+        {
+            get
+            {
                 return _width;
-			}
-			set	
+            }
+            set	
             {
                 if (_worksheet._package.DoAdjustDrawings)
                 {
@@ -173,7 +173,7 @@ namespace OfficeOpenXml
                     _hidden = false;
                 }
             }
-		}
+        }
         /// <summary>
         /// If set to true a column automaticlly resize(grow wider) when a user inputs numbers in a cell. 
         /// </summary>
@@ -196,7 +196,7 @@ namespace OfficeOpenXml
         public bool Phonetic { get; set; }
         #endregion
 
-		#region ExcelColumn Style
+        #region ExcelColumn Style
         /// <summary>
         /// The Style applied to the whole column. Only effects cells with no individual style set. 
         /// Use Range object if you want to set specific styles.
@@ -212,10 +212,10 @@ namespace OfficeOpenXml
         }
         internal string _styleName="";
         /// <summary>
-		/// Sets the style for the entire column using a style name.
-		/// </summary>
-		public string StyleName
-		{
+        /// Sets the style for the entire column using a style name.
+        /// </summary>
+        public string StyleName
+        {
             get
             {
                 return _styleName;
@@ -225,7 +225,7 @@ namespace OfficeOpenXml
                 StyleID = _worksheet.Workbook.Styles.GetStyleIdFromName(value);
                 _styleName = value;
             }
-		}
+        }
         /// <summary>
         /// Sets the style for the entire column using the style ID.           
         /// </summary>
@@ -261,14 +261,14 @@ namespace OfficeOpenXml
         }
         #endregion
 
-		/// <summary>
-		/// Returns the range of columns covered by the column definition.
-		/// </summary>
-		/// <returns>A string describing the range of columns covered by the column definition.</returns>
-		public override string ToString()
-		{
-			return string.Format("Column Range: {0} to {1}", _colElement.GetAttribute("min"), _colElement.GetAttribute("min"));
-		}
+        /// <summary>
+        /// Returns the range of columns covered by the column definition.
+        /// </summary>
+        /// <returns>A string describing the range of columns covered by the column definition.</returns>
+        public override string ToString()
+        {
+            return string.Format("Column Range: {0} to {1}", _colElement.GetAttribute("min"), _colElement.GetAttribute("min"));
+        }
         /// <summary>
         /// Set the column width from the content of the range. The minimum width is the value of the ExcelWorksheet.defaultColumnWidth property.
         /// Note: Cells containing formulas are ignored since EPPlus don't have a calculation engine.

--- a/EPPlus/ExcelComment.cs
+++ b/EPPlus/ExcelComment.cs
@@ -152,8 +152,8 @@ namespace OfficeOpenXml
         /// Reference
         /// </summary>
         internal string Reference
-		{
-			get { return _commentHelper.GetXmlNodeString("@ref"); }
+        {
+            get { return _commentHelper.GetXmlNodeString("@ref"); }
             set
             {
                 var a = new ExcelAddressBase(value);
@@ -172,5 +172,5 @@ namespace OfficeOpenXml
                 Column = Range._fromCol - 1;
             }
         }
-	}
+    }
 }

--- a/EPPlus/ExcelHeaderFooter.cs
+++ b/EPPlus/ExcelHeaderFooter.cs
@@ -62,11 +62,11 @@ namespace OfficeOpenXml
         Right
     }
     #region class ExcelHeaderFooterText
-	/// <summary>
+    /// <summary>
     /// Print header and footer 
     /// </summary>
-	public class ExcelHeaderFooterText
-	{
+    public class ExcelHeaderFooterText
+    {
         ExcelWorksheet _ws;
         string _hf;
         internal ExcelHeaderFooterText(XmlNode TextNode, ExcelWorksheet ws, string hf)
@@ -105,18 +105,18 @@ namespace OfficeOpenXml
                     break;
             }
         }
-		/// <summary>
-		/// Get/set the text to appear on the left hand side of the header (or footer) on the worksheet.
-		/// </summary>
-		public string LeftAlignedText = null;
-		/// <summary>
+        /// <summary>
+        /// Get/set the text to appear on the left hand side of the header (or footer) on the worksheet.
+        /// </summary>
+        public string LeftAlignedText = null;
+        /// <summary>
         /// Get/set the text to appear in the center of the header (or footer) on the worksheet.
-		/// </summary>
-		public string CenteredText = null;
-		/// <summary>
+        /// </summary>
+        public string CenteredText = null;
+        /// <summary>
         /// Get/set the text to appear on the right hand side of the header (or footer) on the worksheet.
-		/// </summary>
-		public string RightAlignedText = null;
+        /// </summary>
+        public string RightAlignedText = null;
         /// <summary>
         /// Inserts a picture at the end of the text in the header or footer
         /// </summary>
@@ -208,50 +208,50 @@ namespace OfficeOpenXml
             }
             return id;
         }
-	}
-	#endregion
+    }
+    #endregion
 
-	#region ExcelHeaderFooter
-	/// <summary>
-	/// Represents the Header and Footer on an Excel Worksheet
-	/// </summary>
-	public sealed class ExcelHeaderFooter : XmlHelper
-	{
-		#region Static Properties
-		/// <summary>
+    #region ExcelHeaderFooter
+    /// <summary>
+    /// Represents the Header and Footer on an Excel Worksheet
+    /// </summary>
+    public sealed class ExcelHeaderFooter : XmlHelper
+    {
+        #region Static Properties
+        /// <summary>
         /// The code for "current page #"
-		/// </summary>
-		public const string PageNumber = @"&P";
-		/// <summary>
+        /// </summary>
+        public const string PageNumber = @"&P";
+        /// <summary>
         /// The code for "total pages"
-		/// </summary>
-		public const string NumberOfPages = @"&N";
+        /// </summary>
+        public const string NumberOfPages = @"&N";
         /// <summary>
         /// The code for "text font color"
         /// RGB Color is specified as RRGGBB
         /// Theme Color is specified as TTSNN where TT is the theme color Id, S is either "+" or "-" of the tint/shade value, NN is the tint/shade value.
         /// </summary>
         public const string FontColor = @"&K";
-		/// <summary>
+        /// <summary>
         /// The code for "sheet tab name"
-		/// </summary>
-		public const string SheetName = @"&A";
-		/// <summary>
+        /// </summary>
+        public const string SheetName = @"&A";
+        /// <summary>
         /// The code for "this workbook's file path"
-		/// </summary>
-		public const string FilePath = @"&Z";
-		/// <summary>
+        /// </summary>
+        public const string FilePath = @"&Z";
+        /// <summary>
         /// The code for "this workbook's file name"
-		/// </summary>
-		public const string FileName = @"&F";
-		/// <summary>
+        /// </summary>
+        public const string FileName = @"&F";
+        /// <summary>
         /// The code for "date"
-		/// </summary>
-		public const string CurrentDate = @"&D";
-		/// <summary>
+        /// </summary>
+        public const string CurrentDate = @"&D";
+        /// <summary>
         /// The code for "time"
-		/// </summary>
-		public const string CurrentTime = @"&T";
+        /// </summary>
+        public const string CurrentTime = @"&T";
         /// <summary>
         /// The code for "picture as background"
         /// </summary>
@@ -264,86 +264,86 @@ namespace OfficeOpenXml
         /// The code for "shadow style"
         /// </summary>
         public const string ShadowStyle = @"&H";
-		#endregion
+        #endregion
 
-		#region ExcelHeaderFooter Private Properties
-		internal ExcelHeaderFooterText _oddHeader;
+        #region ExcelHeaderFooter Private Properties
+        internal ExcelHeaderFooterText _oddHeader;
         internal ExcelHeaderFooterText _oddFooter;
-		internal ExcelHeaderFooterText _evenHeader;
+        internal ExcelHeaderFooterText _evenHeader;
         internal ExcelHeaderFooterText _evenFooter;
         internal ExcelHeaderFooterText _firstHeader;
         internal ExcelHeaderFooterText _firstFooter;
         private ExcelWorksheet _ws;
         #endregion
 
-		#region ExcelHeaderFooter Constructor
-		/// <summary>
-		/// ExcelHeaderFooter Constructor
-		/// </summary>
-		/// <param name="nameSpaceManager"></param>
+        #region ExcelHeaderFooter Constructor
+        /// <summary>
+        /// ExcelHeaderFooter Constructor
+        /// </summary>
+        /// <param name="nameSpaceManager"></param>
         /// <param name="topNode"></param>
         /// <param name="ws">The worksheet</param>
-		internal ExcelHeaderFooter(XmlNamespaceManager nameSpaceManager, XmlNode topNode, ExcelWorksheet ws) :
+        internal ExcelHeaderFooter(XmlNamespaceManager nameSpaceManager, XmlNode topNode, ExcelWorksheet ws) :
             base(nameSpaceManager, topNode)
-		{
+        {
             _ws = ws;
             SchemaNodeOrder = new string[] { "headerFooter", "oddHeader", "oddFooter", "evenHeader", "evenFooter", "firstHeader", "firstFooter" };
-		}
-		#endregion
+        }
+        #endregion
 
-		#region alignWithMargins
+        #region alignWithMargins
         const string alignWithMarginsPath="@alignWithMargins";
         /// <summary>
-		/// Gets/sets the alignWithMargins attribute
-		/// </summary>
-		public bool AlignWithMargins
-		{
-			get
-			{
+        /// Gets/sets the alignWithMargins attribute
+        /// </summary>
+        public bool AlignWithMargins
+        {
+            get
+            {
                 return GetXmlNodeBool(alignWithMarginsPath);
-			}
-			set
-			{
+            }
+            set
+            {
                 SetXmlNodeString(alignWithMarginsPath, value ? "1" : "0");
-			}
-		}
-		#endregion
+            }
+        }
+        #endregion
 
         #region differentOddEven
         const string differentOddEvenPath = "@differentOddEven";
         /// <summary>
-		/// Gets/sets the flag that tells Excel to display different headers and footers on odd and even pages.
-		/// </summary>
-		public bool differentOddEven
-		{
-			get
-			{
+        /// Gets/sets the flag that tells Excel to display different headers and footers on odd and even pages.
+        /// </summary>
+        public bool differentOddEven
+        {
+            get
+            {
                 return GetXmlNodeBool(differentOddEvenPath);
-			}
-			set
-			{
+            }
+            set
+            {
                 SetXmlNodeString(differentOddEvenPath, value ? "1" : "0");
-			}
-		}
-		#endregion
+            }
+        }
+        #endregion
 
-		#region differentFirst
+        #region differentFirst
         const string differentFirstPath = "@differentFirst";
 
-		/// <summary>
-		/// Gets/sets the flag that tells Excel to display different headers and footers on the first page of the worksheet.
-		/// </summary>
-		public bool differentFirst
-		{
-			get
-			{
+        /// <summary>
+        /// Gets/sets the flag that tells Excel to display different headers and footers on the first page of the worksheet.
+        /// </summary>
+        public bool differentFirst
+        {
+            get
+            {
                 return GetXmlNodeBool(differentFirstPath);
-			}
-			set
-			{
+            }
+            set
+            {
                 SetXmlNodeString(differentFirstPath, value ? "1" : "0");
-			}
-		}
+            }
+        }
         #endregion
         #region ScaleWithDoc
         const string scaleWithDocPath = "@scaleWithDoc";
@@ -377,11 +377,11 @@ namespace OfficeOpenXml
                 }
                 return _oddHeader; } 
         }
-		/// <summary>
-		/// Provides access to the footer on odd numbered pages of the document.
-		/// If you want the same footer on both odd and even pages, then only set values in this ExcelHeaderFooterText class.
-		/// </summary>
-		public ExcelHeaderFooterText OddFooter 
+        /// <summary>
+        /// Provides access to the footer on odd numbered pages of the document.
+        /// If you want the same footer on both odd and even pages, then only set values in this ExcelHeaderFooterText class.
+        /// </summary>
+        public ExcelHeaderFooterText OddFooter 
         { 
             get 
             {
@@ -392,11 +392,11 @@ namespace OfficeOpenXml
                 return _oddFooter; 
             } 
         }
-		// evenHeader and evenFooter set differentOddEven = true
-		/// <summary>
-		/// Provides access to the header on even numbered pages of the document.
-		/// </summary>
-		public ExcelHeaderFooterText EvenHeader 
+        // evenHeader and evenFooter set differentOddEven = true
+        /// <summary>
+        /// Provides access to the header on even numbered pages of the document.
+        /// </summary>
+        public ExcelHeaderFooterText EvenHeader 
         { 
             get 
             {
@@ -408,10 +408,10 @@ namespace OfficeOpenXml
                 return _evenHeader; 
             } 
         }
-		/// <summary>
-		/// Provides access to the footer on even numbered pages of the document.
-		/// </summary>
-		public ExcelHeaderFooterText EvenFooter
+        /// <summary>
+        /// Provides access to the footer on even numbered pages of the document.
+        /// </summary>
+        public ExcelHeaderFooterText EvenFooter
         { 
             get 
             {
@@ -423,10 +423,10 @@ namespace OfficeOpenXml
                 return _evenFooter ; 
             } 
         }
-		/// <summary>
-		/// Provides access to the header on the first page of the document.
-		/// </summary>
-		public ExcelHeaderFooterText FirstHeader
+        /// <summary>
+        /// Provides access to the header on the first page of the document.
+        /// </summary>
+        public ExcelHeaderFooterText FirstHeader
         { 
             get 
             {
@@ -438,10 +438,10 @@ namespace OfficeOpenXml
                 return _firstHeader; 
             } 
         }
-		/// <summary>
-		/// Provides access to the footer on the first page of the document.
-		/// </summary>
-		public ExcelHeaderFooterText FirstFooter
+        /// <summary>
+        /// Provides access to the footer on the first page of the document.
+        /// </summary>
+        public ExcelHeaderFooterText FirstFooter
         { 
             get 
             {
@@ -489,42 +489,42 @@ namespace OfficeOpenXml
             /// Saves the header and footer information to the worksheet XML
             /// </summary>
         internal void Save()
-		{
-			if (_oddHeader != null)
-			{
+        {
+            if (_oddHeader != null)
+            {
                 SetXmlNodeString("d:oddHeader", GetText(OddHeader));
-			}
-			if (_oddFooter != null)
-			{
+            }
+            if (_oddFooter != null)
+            {
                 SetXmlNodeString("d:oddFooter", GetText(OddFooter));
-			}
+            }
 
-			// only set evenHeader and evenFooter 
-			if (differentOddEven)
-			{
-				if (_evenHeader != null)
-				{
+            // only set evenHeader and evenFooter 
+            if (differentOddEven)
+            {
+                if (_evenHeader != null)
+                {
                     SetXmlNodeString("d:evenHeader", GetText(EvenHeader));
-				}
-				if (_evenFooter != null)
-				{
+                }
+                if (_evenFooter != null)
+                {
                     SetXmlNodeString("d:evenFooter", GetText(EvenFooter));
-				}
-			}
+                }
+            }
 
-			// only set firstHeader and firstFooter
-			if (differentFirst)
-			{
-				if (_firstHeader != null)
-				{
+            // only set firstHeader and firstFooter
+            if (differentFirst)
+            {
+                if (_firstHeader != null)
+                {
                     SetXmlNodeString("d:firstHeader", GetText(FirstHeader));
-				}
-				if (_firstFooter != null)
-				{
+                }
+                if (_firstFooter != null)
+                {
                     SetXmlNodeString("d:firstFooter", GetText(FirstFooter));
-				}
-			}
-		}
+                }
+            }
+        }
         internal void SaveHeaderFooterImages()
         {
             if (_vmlDrawingsHF != null)
@@ -559,18 +559,18 @@ namespace OfficeOpenXml
                 }
             }
         }
-		private string GetText(ExcelHeaderFooterText headerFooter)
-		{
-			string ret = "";
-			if (headerFooter.LeftAlignedText != null)
-				ret += "&L" + headerFooter.LeftAlignedText;
-			if (headerFooter.CenteredText != null)
-				ret += "&C" + headerFooter.CenteredText;
-			if (headerFooter.RightAlignedText != null)
-				ret += "&R" + headerFooter.RightAlignedText;
-			return ret;
-		}
-		#endregion
-	}
-	#endregion
+        private string GetText(ExcelHeaderFooterText headerFooter)
+        {
+            string ret = "";
+            if (headerFooter.LeftAlignedText != null)
+                ret += "&L" + headerFooter.LeftAlignedText;
+            if (headerFooter.CenteredText != null)
+                ret += "&C" + headerFooter.CenteredText;
+            if (headerFooter.RightAlignedText != null)
+                ret += "&R" + headerFooter.RightAlignedText;
+            return ret;
+        }
+        #endregion
+    }
+    #endregion
 }

--- a/EPPlus/ExcelPackage.cs
+++ b/EPPlus/ExcelPackage.cs
@@ -78,13 +78,13 @@ namespace OfficeOpenXml
     /// <remarks>
     /// <example>
     /// <code>
-	///     FileInfo newFile = new FileInfo(outputDir.FullName + @"\sample1.xlsx");
-	/// 	if (newFile.Exists)
-	/// 	{
-	/// 		newFile.Delete();  // ensures we create a new workbook
-	/// 		newFile = new FileInfo(outputDir.FullName + @"\sample1.xlsx");
-	/// 	}
-	/// 	using (ExcelPackage package = new ExcelPackage(newFile))
+    ///     FileInfo newFile = new FileInfo(outputDir.FullName + @"\sample1.xlsx");
+    /// 	if (newFile.Exists)
+    /// 	{
+    /// 		newFile.Delete();  // ensures we create a new workbook
+    /// 		newFile = new FileInfo(outputDir.FullName + @"\sample1.xlsx");
+    /// 	}
+    /// 	using (ExcelPackage package = new ExcelPackage(newFile))
     ///     {
     ///         // add a new worksheet to the empty workbook
     ///         ExcelWorksheet worksheet = package.Workbook.Worksheets.Add("Inventory");
@@ -173,8 +173,8 @@ namespace OfficeOpenXml
     /// More samples can be found at  <a href="https://github.com/JanKallman/EPPlus/">https://github.com/JanKallman/EPPlus/</a>
     /// </example>
     /// </remarks>
-	public sealed class ExcelPackage : IDisposable
-	{
+    public sealed class ExcelPackage : IDisposable
+    {
         internal const bool preserveWhitespace=false;
         Stream _stream = null;
         private bool _isExternalStream=false;
@@ -186,21 +186,21 @@ namespace OfficeOpenXml
             internal Packaging.ZipPackagePart Part { get; set; }
         }
         internal Dictionary<string, ImageInfo> _images = new Dictionary<string, ImageInfo>();
-		#region Properties
-		/// <summary>
-		/// Extention Schema types
-		/// </summary>
+        #region Properties
+        /// <summary>
+        /// Extention Schema types
+        /// </summary>
         internal const string schemaXmlExtension = "application/xml";
         internal const string schemaRelsExtension = "application/vnd.openxmlformats-package.relationships+xml";
         /// <summary>
-		/// Main Xml schema name
-		/// </summary>
-		internal const string schemaMain = @"http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        /// Main Xml schema name
+        /// </summary>
+        internal const string schemaMain = @"http://schemas.openxmlformats.org/spreadsheetml/2006/main";
                                             
-		/// <summary>
-		/// Relationship schema name
-		/// </summary>
-		internal const string schemaRelationships = @"http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        /// <summary>
+        /// Relationship schema name
+        /// </summary>
+        internal const string schemaRelationships = @"http://schemas.openxmlformats.org/officeDocument/2006/relationships";
                                                                               
         internal const string schemaDrawings = @"http://schemas.openxmlformats.org/drawingml/2006/main";
         internal const string schemaSheetDrawings = @"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
@@ -243,7 +243,7 @@ namespace OfficeOpenXml
         internal const string contentTypeSharedString = @"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml";
         //Package reference
         private Packaging.ZipPackage _package;
-		internal ExcelWorkbook _workbook;
+        internal ExcelWorkbook _workbook;
         /// <summary>
         /// Maximum number of columns in a worksheet (16384). 
         /// </summary>
@@ -252,8 +252,8 @@ namespace OfficeOpenXml
         /// Maximum number of rows in a worksheet (1048576). 
         /// </summary>
         public const int MaxRows = 1048576;
-		#endregion
-		#region ExcelPackage Constructors
+        #endregion
+        #region ExcelPackage Constructors
         /// <summary>
         /// Create a new instance of the ExcelPackage. 
         /// Output is accessed through the Stream property, using the <see cref="SaveAs(FileInfo)"/> method or later set the <see cref="File" /> property.
@@ -264,11 +264,11 @@ namespace OfficeOpenXml
             ConstructNewFile(null);
         }
         /// <summary>
-		/// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
-		/// </summary>
-		/// <param name="newFile">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
+        /// Create a new instance of the ExcelPackage class based on a existing file or creates a new file. 
+        /// </summary>
+        /// <param name="newFile">If newFile exists, it is opened.  Otherwise it is created from scratch.</param>
         public ExcelPackage(FileInfo newFile)
-		{
+        {
             Init();
             File = newFile;
             ConstructNewFile(null);
@@ -284,18 +284,18 @@ namespace OfficeOpenXml
             File = newFile;
             ConstructNewFile(password);
         }
-		/// <summary>
-		/// Create a new instance of the ExcelPackage class based on a existing template.
-		/// If newFile exists, it will be overwritten when the Save method is called
-		/// </summary>
-		/// <param name="newFile">The name of the Excel file to be created</param>
-		/// <param name="template">The name of the Excel template to use as the basis of the new Excel file</param>
-		public ExcelPackage(FileInfo newFile, FileInfo template)
-		{
+        /// <summary>
+        /// Create a new instance of the ExcelPackage class based on a existing template.
+        /// If newFile exists, it will be overwritten when the Save method is called
+        /// </summary>
+        /// <param name="newFile">The name of the Excel file to be created</param>
+        /// <param name="template">The name of the Excel template to use as the basis of the new Excel file</param>
+        public ExcelPackage(FileInfo newFile, FileInfo template)
+        {
             Init();
             File = newFile;
             CreateFromTemplate(template, null);
-		}
+        }
         /// <summary>
         /// Create a new instance of the ExcelPackage class based on a existing template.
         /// If newFile exists, it will be overwritten when the Save method is called
@@ -659,10 +659,10 @@ namespace OfficeOpenXml
             _package.CreateRelationship(UriHelper.GetRelativeUri(new Uri("/xl", UriKind.Relative), Workbook.WorkbookUri), Packaging.TargetMode.Internal, schemaRelationships + "/officeDocument");
         }
 
-		/// <summary>
-		/// Returns a reference to the package
-		/// </summary>
-		public Packaging.ZipPackage Package { get { return (_package); } }
+        /// <summary>
+        /// Returns a reference to the package
+        /// </summary>
+        public Packaging.ZipPackage Package { get { return (_package); } }
         ExcelEncryption _encryption=null;
         /// <summary>
         /// Information how and if the package is encrypted
@@ -678,14 +678,14 @@ namespace OfficeOpenXml
                 return _encryption;
             }
         }
-		/// <summary>
-		/// Returns a reference to the workbook component within the package.
-		/// All worksheets and cells can be accessed through the workbook.
-		/// </summary>
-		public ExcelWorkbook Workbook
-		{
-			get
-			{
+        /// <summary>
+        /// Returns a reference to the workbook component within the package.
+        /// All worksheets and cells can be accessed through the workbook.
+        /// </summary>
+        public ExcelWorkbook Workbook
+        {
+            get
+            {
                 if (_workbook == null)
                 {
                     var nsm = CreateDefaultNSM();
@@ -697,8 +697,8 @@ namespace OfficeOpenXml
 
                 }
                 return (_workbook);
-			}
-		}
+            }
+        }
         /// <summary>
         /// Automaticlly adjust drawing size when column width/row height are adjusted, depending on the drawings editBy property.
         /// Default True
@@ -738,29 +738,29 @@ namespace OfficeOpenXml
 
             return ns;
         }
-		
+        
 #region SavePart
-		/// <summary>
-		/// Saves the XmlDocument into the package at the specified Uri.
-		/// </summary>
-		/// <param name="uri">The Uri of the component</param>
-		/// <param name="xmlDoc">The XmlDocument to save</param>
-		internal void SavePart(Uri uri, XmlDocument xmlDoc)
-		{
+        /// <summary>
+        /// Saves the XmlDocument into the package at the specified Uri.
+        /// </summary>
+        /// <param name="uri">The Uri of the component</param>
+        /// <param name="xmlDoc">The XmlDocument to save</param>
+        internal void SavePart(Uri uri, XmlDocument xmlDoc)
+        {
             Packaging.ZipPackagePart part = _package.GetPart(uri);
             var stream = part.GetStream(FileMode.Create, FileAccess.Write);
             var xr = new XmlTextWriter(stream, Encoding.UTF8);
             xr.Formatting = Formatting.None;
             
             xmlDoc.Save(xr);
-		}
+        }
         /// <summary>
-		/// Saves the XmlDocument into the package at the specified Uri.
-		/// </summary>
-		/// <param name="uri">The Uri of the component</param>
-		/// <param name="xmlDoc">The XmlDocument to save</param>
+        /// Saves the XmlDocument into the package at the specified Uri.
+        /// </summary>
+        /// <param name="uri">The Uri of the component</param>
+        /// <param name="xmlDoc">The XmlDocument to save</param>
         internal void SaveWorkbook(Uri uri, XmlDocument xmlDoc)
-		{
+        {
             Packaging.ZipPackagePart part = _package.GetPart(uri);
             if(Workbook.VbaProject==null)
             {
@@ -788,19 +788,19 @@ namespace OfficeOpenXml
             xr.Formatting = Formatting.None;
 
             xmlDoc.Save(xr);
-		}
+        }
 
 #endregion
 
 #region Dispose
-		/// <summary>
-		/// Closes the package.
-		/// </summary>
-		public void Dispose()
-		{
+        /// <summary>
+        /// Closes the package.
+        /// </summary>
+        public void Dispose()
+        {
             if(_package != null)
             {
-		        if (_isExternalStream==false && _stream != null && (_stream.CanRead || _stream.CanWrite))
+                if (_isExternalStream==false && _stream != null && (_stream.CanRead || _stream.CanWrite))
                 {
                     CloseStream();
                 }
@@ -817,7 +817,7 @@ namespace OfficeOpenXml
                 _workbook = null;
                 GC.Collect();
             }
-		}
+        }
         #endregion
 
         #region Save  // ExcelPackage save
@@ -919,7 +919,7 @@ namespace OfficeOpenXml
         /// </summary>
         /// <param name="password">This parameter overrides the Workbook.Encryption.Password.</param>
         public void Save(string password)
-		{
+        {
             Encryption.Password = password;
             Save();
         }
@@ -1051,12 +1051,12 @@ namespace OfficeOpenXml
         /// <param name="uri">The Uri to the part</param>
         /// <returns>The XmlDocument</returns>
         internal XmlDocument GetXmlFromUri(Uri uri)
-		{
-			XmlDocument xml = new XmlDocument();
-			Packaging.ZipPackagePart part = _package.GetPart(uri);
+        {
+            XmlDocument xml = new XmlDocument();
+            Packaging.ZipPackagePart part = _package.GetPart(uri);
             XmlHelper.LoadXmlSafe(xml, part.GetStream()); 
-			return (xml);
-		}
+            return (xml);
+        }
 #endregion
 
         /// <summary>
@@ -1071,7 +1071,7 @@ namespace OfficeOpenXml
         ///  Byte[] bin = package.GetAsByteArray();
         ///  Response.ContentType = "Application/vnd.ms-Excel";
         ///  Response.AddHeader("content-disposition", "attachment;  filename=TheFile.xlsx");
-		///  Response.BinaryWrite(bin);
+        ///  Response.BinaryWrite(bin);
         /// </code>
         /// </example>
         /// <returns></returns>

--- a/EPPlus/ExcelRangeBase.cs
+++ b/EPPlus/ExcelRangeBase.cs
@@ -61,19 +61,19 @@ using OfficeOpenXml.Compatibility;
 namespace OfficeOpenXml
 {	
     /// <summary>
-	/// A range of cells 
-	/// </summary>
-	public class ExcelRangeBase : ExcelAddress, IExcelCell, IDisposable, IEnumerable<ExcelRangeBase>, IEnumerator<ExcelRangeBase>
-	{
-		/// <summary>
-		/// Reference to the worksheet
-		/// </summary>
-		protected ExcelWorksheet _worksheet;
-		internal ExcelWorkbook _workbook = null;
-		private delegate void _changeProp(ExcelRangeBase range, _setValue method, object value);
-		private delegate void _setValue(ExcelRangeBase range, object value, int row, int col);
+    /// A range of cells 
+    /// </summary>
+    public class ExcelRangeBase : ExcelAddress, IExcelCell, IDisposable, IEnumerable<ExcelRangeBase>, IEnumerator<ExcelRangeBase>
+    {
+        /// <summary>
+        /// Reference to the worksheet
+        /// </summary>
+        protected ExcelWorksheet _worksheet;
+        internal ExcelWorkbook _workbook = null;
+        private delegate void _changeProp(ExcelRangeBase range, _setValue method, object value);
+        private delegate void _setValue(ExcelRangeBase range, object value, int row, int col);
         private _changeProp _changePropMethod;
-		private int _styleID;
+        private int _styleID;
         private class CopiedCell
         {
             internal int Row { get; set; }
@@ -87,12 +87,12 @@ namespace OfficeOpenXml
             internal Byte Flag { get; set; }
         }
         #region Constructors
-		internal ExcelRangeBase(ExcelWorksheet xlWorksheet)
-		{
-			_worksheet = xlWorksheet;
-			_ws = _worksheet.Name;
+        internal ExcelRangeBase(ExcelWorksheet xlWorksheet)
+        {
+            _worksheet = xlWorksheet;
+            _ws = _worksheet.Name;
             _workbook = _worksheet.Workbook;
-			SetDelegate();
+            SetDelegate();
         }
         /// <summary>
         /// On change address handler
@@ -105,117 +105,117 @@ namespace OfficeOpenXml
             }
             SetDelegate();
         }
-		internal ExcelRangeBase(ExcelWorksheet xlWorksheet, string address) :
-			base(xlWorksheet == null ? "" : xlWorksheet.Name, address)
-		{
-			_worksheet = xlWorksheet;
+        internal ExcelRangeBase(ExcelWorksheet xlWorksheet, string address) :
+            base(xlWorksheet == null ? "" : xlWorksheet.Name, address)
+        {
+            _worksheet = xlWorksheet;
             _workbook = _worksheet.Workbook;
             base.SetRCFromTable(_worksheet._package, null);
-			if (string.IsNullOrEmpty(_ws)) _ws = _worksheet == null ? "" : _worksheet.Name;
-            SetDelegate();
-		}
-		internal ExcelRangeBase(ExcelWorkbook wb, ExcelWorksheet xlWorksheet, string address, bool isName) :
-			base(xlWorksheet == null ? "" : xlWorksheet.Name, address, isName)
-		{
-            SetRCFromTable(wb._package, null);
-            _worksheet = xlWorksheet;
-			_workbook = wb;
-			if (string.IsNullOrEmpty(_ws)) _ws = (xlWorksheet == null ? null : xlWorksheet.Name);
+            if (string.IsNullOrEmpty(_ws)) _ws = _worksheet == null ? "" : _worksheet.Name;
             SetDelegate();
         }
-		#endregion
-		#region Set Value Delegates        
-		private static _changeProp _setUnknownProp = SetUnknown;
-		private static _changeProp _setSingleProp = SetSingle;
-		private static _changeProp _setRangeProp = SetRange;
-		private static _changeProp _setMultiProp = SetMultiRange;
-		private void SetDelegate()
-		{
-			if (_fromRow == -1)
-			{
-				_changePropMethod = SetUnknown;
-			}
-			//Single cell
-			else if (_fromRow == _toRow && _fromCol == _toCol && Addresses == null)
-			{
-				_changePropMethod = SetSingle;
-			}
-			//Range (ex A1:A2)
-			else if (Addresses == null)
-			{
-				_changePropMethod = SetRange;
-			}
-			//Multi Range (ex A1:A2,C1:C2)
-			else
-			{
-				_changePropMethod = SetMultiRange;
-			}
-		}
-		/// <summary>
-		/// We dont know the address yet. Set the delegate first time a property is set.
-		/// </summary>
-		/// <param name="range"></param>
-		/// <param name="valueMethod"></param>
-		/// <param name="value"></param>
-		private static void SetUnknown(ExcelRangeBase range, _setValue valueMethod, object value)
-		{
-			//Address is not set use, selected range
-			if (range._fromRow == -1)
-			{
-				range.SetToSelectedRange();
-			}
-			range.SetDelegate();
-			range._changePropMethod(range, valueMethod, value);
-		}
-		/// <summary>
-		/// Set a single cell
-		/// </summary>
-		/// <param name="range"></param>
-		/// <param name="valueMethod"></param>
-		/// <param name="value"></param>
-		private static void SetSingle(ExcelRangeBase range, _setValue valueMethod, object value)
-		{
-			valueMethod(range, value, range._fromRow, range._fromCol);
-		}
-		/// <summary>
-		/// Set a range
-		/// </summary>
-		/// <param name="range"></param>
-		/// <param name="valueMethod"></param>
-		/// <param name="value"></param>
-		private static void SetRange(ExcelRangeBase range, _setValue valueMethod, object value)
-		{
-			range.SetValueAddress(range, valueMethod, value);
-		}
-		/// <summary>
-		/// Set a multirange (A1:A2,C1:C2)
-		/// </summary>
-		/// <param name="range"></param>
-		/// <param name="valueMethod"></param>
-		/// <param name="value"></param>
-		private static void SetMultiRange(ExcelRangeBase range, _setValue valueMethod, object value)
-		{
-			range.SetValueAddress(range, valueMethod, value);
-			foreach (var address in range.Addresses)
-			{
-				range.SetValueAddress(address, valueMethod, value);
-			}
-		}
-		/// <summary>
-		/// Set the property for an address
-		/// </summary>
-		/// <param name="address"></param>
-		/// <param name="valueMethod"></param>
-		/// <param name="value"></param>
-		private void SetValueAddress(ExcelAddress address, _setValue valueMethod, object value)
-		{
-			IsRangeValid("");
-			if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows && _toCol == ExcelPackage.MaxColumns)  //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
-			{
-				throw (new ArgumentException("Can't reference all cells. Please use the indexer to set the range"));
-			}
-			else
-			{
+        internal ExcelRangeBase(ExcelWorkbook wb, ExcelWorksheet xlWorksheet, string address, bool isName) :
+            base(xlWorksheet == null ? "" : xlWorksheet.Name, address, isName)
+        {
+            SetRCFromTable(wb._package, null);
+            _worksheet = xlWorksheet;
+            _workbook = wb;
+            if (string.IsNullOrEmpty(_ws)) _ws = (xlWorksheet == null ? null : xlWorksheet.Name);
+            SetDelegate();
+        }
+        #endregion
+        #region Set Value Delegates        
+        private static _changeProp _setUnknownProp = SetUnknown;
+        private static _changeProp _setSingleProp = SetSingle;
+        private static _changeProp _setRangeProp = SetRange;
+        private static _changeProp _setMultiProp = SetMultiRange;
+        private void SetDelegate()
+        {
+            if (_fromRow == -1)
+            {
+                _changePropMethod = SetUnknown;
+            }
+            //Single cell
+            else if (_fromRow == _toRow && _fromCol == _toCol && Addresses == null)
+            {
+                _changePropMethod = SetSingle;
+            }
+            //Range (ex A1:A2)
+            else if (Addresses == null)
+            {
+                _changePropMethod = SetRange;
+            }
+            //Multi Range (ex A1:A2,C1:C2)
+            else
+            {
+                _changePropMethod = SetMultiRange;
+            }
+        }
+        /// <summary>
+        /// We dont know the address yet. Set the delegate first time a property is set.
+        /// </summary>
+        /// <param name="range"></param>
+        /// <param name="valueMethod"></param>
+        /// <param name="value"></param>
+        private static void SetUnknown(ExcelRangeBase range, _setValue valueMethod, object value)
+        {
+            //Address is not set use, selected range
+            if (range._fromRow == -1)
+            {
+                range.SetToSelectedRange();
+            }
+            range.SetDelegate();
+            range._changePropMethod(range, valueMethod, value);
+        }
+        /// <summary>
+        /// Set a single cell
+        /// </summary>
+        /// <param name="range"></param>
+        /// <param name="valueMethod"></param>
+        /// <param name="value"></param>
+        private static void SetSingle(ExcelRangeBase range, _setValue valueMethod, object value)
+        {
+            valueMethod(range, value, range._fromRow, range._fromCol);
+        }
+        /// <summary>
+        /// Set a range
+        /// </summary>
+        /// <param name="range"></param>
+        /// <param name="valueMethod"></param>
+        /// <param name="value"></param>
+        private static void SetRange(ExcelRangeBase range, _setValue valueMethod, object value)
+        {
+            range.SetValueAddress(range, valueMethod, value);
+        }
+        /// <summary>
+        /// Set a multirange (A1:A2,C1:C2)
+        /// </summary>
+        /// <param name="range"></param>
+        /// <param name="valueMethod"></param>
+        /// <param name="value"></param>
+        private static void SetMultiRange(ExcelRangeBase range, _setValue valueMethod, object value)
+        {
+            range.SetValueAddress(range, valueMethod, value);
+            foreach (var address in range.Addresses)
+            {
+                range.SetValueAddress(address, valueMethod, value);
+            }
+        }
+        /// <summary>
+        /// Set the property for an address
+        /// </summary>
+        /// <param name="address"></param>
+        /// <param name="valueMethod"></param>
+        /// <param name="value"></param>
+        private void SetValueAddress(ExcelAddress address, _setValue valueMethod, object value)
+        {
+            IsRangeValid("");
+            if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows && _toCol == ExcelPackage.MaxColumns)  //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
+            {
+                throw (new ArgumentException("Can't reference all cells. Please use the indexer to set the range"));
+            }
+            else
+            {
                 if (value is object[,] && valueMethod == Set_Value)
                 {
                     // only simple set value is supported for bulk copy
@@ -231,167 +231,167 @@ namespace OfficeOpenXml
                         }
                     }
                 }
-			}
+            }
         }
-		#endregion
-		#region Set property methods
-		private static _setValue _setStyleIdDelegate = Set_StyleID;
-		private static _setValue _setValueDelegate = Set_Value;
-		private static _setValue _setHyperLinkDelegate = Set_HyperLink;
-		private static _setValue _setIsRichTextDelegate = Set_IsRichText;
-		private static _setValue _setExistsCommentDelegate = Exists_Comment;
-		private static _setValue _setCommentDelegate = Set_Comment;
+        #endregion
+        #region Set property methods
+        private static _setValue _setStyleIdDelegate = Set_StyleID;
+        private static _setValue _setValueDelegate = Set_Value;
+        private static _setValue _setHyperLinkDelegate = Set_HyperLink;
+        private static _setValue _setIsRichTextDelegate = Set_IsRichText;
+        private static _setValue _setExistsCommentDelegate = Exists_Comment;
+        private static _setValue _setCommentDelegate = Set_Comment;
 
-		private static void Set_StyleID(ExcelRangeBase range, object value, int row, int col)
-		{
-			range._worksheet.SetStyleInner(row, col, (int)value);
-		}
-		private static void Set_StyleName(ExcelRangeBase range, object value, int row, int col)
-		{
-			range._worksheet.SetStyleInner(row, col, range._styleID);
-		}
-		private static void Set_Value(ExcelRangeBase range, object value, int row, int col)
-		{
-			var sfi = range._worksheet._formulas.GetValue(row, col);
-			if (sfi is int)
-			{
-				range.SplitFormulas(range._worksheet.Cells[row, col]);                
-			}
-			if (sfi != null) range._worksheet._formulas.SetValue(row, col, string.Empty);
-			range._worksheet.SetValueInner(row, col, value);
-		}
-		private static void Set_Formula(ExcelRangeBase range, object value, int row, int col)
-		{
-			var f = range._worksheet._formulas.GetValue(row, col);
-			if (f is int && (int)f >= 0) range.SplitFormulas(range._worksheet.Cells[row, col]);
+        private static void Set_StyleID(ExcelRangeBase range, object value, int row, int col)
+        {
+            range._worksheet.SetStyleInner(row, col, (int)value);
+        }
+        private static void Set_StyleName(ExcelRangeBase range, object value, int row, int col)
+        {
+            range._worksheet.SetStyleInner(row, col, range._styleID);
+        }
+        private static void Set_Value(ExcelRangeBase range, object value, int row, int col)
+        {
+            var sfi = range._worksheet._formulas.GetValue(row, col);
+            if (sfi is int)
+            {
+                range.SplitFormulas(range._worksheet.Cells[row, col]);                
+            }
+            if (sfi != null) range._worksheet._formulas.SetValue(row, col, string.Empty);
+            range._worksheet.SetValueInner(row, col, value);
+        }
+        private static void Set_Formula(ExcelRangeBase range, object value, int row, int col)
+        {
+            var f = range._worksheet._formulas.GetValue(row, col);
+            if (f is int && (int)f >= 0) range.SplitFormulas(range._worksheet.Cells[row, col]);
 
-			string formula = (value == null ? string.Empty : value.ToString());
-			if (formula == string.Empty)
-			{
+            string formula = (value == null ? string.Empty : value.ToString());
+            if (formula == string.Empty)
+            {
                 range._worksheet._formulas.SetValue(row, col, string.Empty);
-			}
-			else
-			{
-				if (formula[0] == '=') value = formula.Substring(1, formula.Length - 1); // remove any starting equalsign.
-				range._worksheet._formulas.SetValue(row, col, formula);
-				range._worksheet.SetValueInner(row, col, null);
-			}
-		}
-		/// <summary>
-		/// Handles shared formulas
-		/// </summary>
-		/// <param name="range">The range</param>
+            }
+            else
+            {
+                if (formula[0] == '=') value = formula.Substring(1, formula.Length - 1); // remove any starting equalsign.
+                range._worksheet._formulas.SetValue(row, col, formula);
+                range._worksheet.SetValueInner(row, col, null);
+            }
+        }
+        /// <summary>
+        /// Handles shared formulas
+        /// </summary>
+        /// <param name="range">The range</param>
         /// <param name="value">The  formula</param>
-		/// <param name="address">The address of the formula</param>
-		/// <param name="IsArray">If the forumla is an array formula.</param>
-		private static void Set_SharedFormula(ExcelRangeBase range, string value, ExcelAddress address, bool IsArray)
-		{
-			if (range._fromRow == 1 && range._fromCol == 1 && range._toRow == ExcelPackage.MaxRows && range._toCol == ExcelPackage.MaxColumns)  //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
-			{
-				throw (new InvalidOperationException("Can't set a formula for the entire worksheet"));
-			}
-			else if (address.Start.Row == address.End.Row && address.Start.Column == address.End.Column && !IsArray)             //is it really a shared formula? Arrayformulas can be one cell only
-			{
-				//Nope, single cell. Set the formula
-				Set_Formula(range, value, address.Start.Row, address.Start.Column);
-				return;
-			}
-			range.CheckAndSplitSharedFormula(address);
-			ExcelWorksheet.Formulas f = new ExcelWorksheet.Formulas(SourceCodeTokenizer.Default);
-			f.Formula = value;
-			f.Index = range._worksheet.GetMaxShareFunctionIndex(IsArray);
-			f.Address = address.FirstAddress;
-			f.StartCol = address.Start.Column;
-			f.StartRow = address.Start.Row;
-			f.IsArray = IsArray;
+        /// <param name="address">The address of the formula</param>
+        /// <param name="IsArray">If the forumla is an array formula.</param>
+        private static void Set_SharedFormula(ExcelRangeBase range, string value, ExcelAddress address, bool IsArray)
+        {
+            if (range._fromRow == 1 && range._fromCol == 1 && range._toRow == ExcelPackage.MaxRows && range._toCol == ExcelPackage.MaxColumns)  //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
+            {
+                throw (new InvalidOperationException("Can't set a formula for the entire worksheet"));
+            }
+            else if (address.Start.Row == address.End.Row && address.Start.Column == address.End.Column && !IsArray)             //is it really a shared formula? Arrayformulas can be one cell only
+            {
+                //Nope, single cell. Set the formula
+                Set_Formula(range, value, address.Start.Row, address.Start.Column);
+                return;
+            }
+            range.CheckAndSplitSharedFormula(address);
+            ExcelWorksheet.Formulas f = new ExcelWorksheet.Formulas(SourceCodeTokenizer.Default);
+            f.Formula = value;
+            f.Index = range._worksheet.GetMaxShareFunctionIndex(IsArray);
+            f.Address = address.FirstAddress;
+            f.StartCol = address.Start.Column;
+            f.StartRow = address.Start.Row;
+            f.IsArray = IsArray;
 
-			range._worksheet._sharedFormulas.Add(f.Index, f);
+            range._worksheet._sharedFormulas.Add(f.Index, f);
 
-			for (int col = address.Start.Column; col <= address.End.Column; col++)
-			{
-				for (int row = address.Start.Row; row <= address.End.Row; row++)
-				{
-					range._worksheet._formulas.SetValue(row, col, f.Index);
+            for (int col = address.Start.Column; col <= address.End.Column; col++)
+            {
+                for (int row = address.Start.Row; row <= address.End.Row; row++)
+                {
+                    range._worksheet._formulas.SetValue(row, col, f.Index);
                     range._worksheet._flags.SetFlagValue(row, col, true, CellFlags.ArrayFormula);
-					range._worksheet.SetValueInner(row, col, null);
-				}
-			}
-		}
-		private static void Set_HyperLink(ExcelRangeBase range, object value, int row, int col)
-		{
-			if (value is Uri)
-			{
-				range._worksheet._hyperLinks.SetValue(row, col, (Uri)value);
+                    range._worksheet.SetValueInner(row, col, null);
+                }
+            }
+        }
+        private static void Set_HyperLink(ExcelRangeBase range, object value, int row, int col)
+        {
+            if (value is Uri)
+            {
+                range._worksheet._hyperLinks.SetValue(row, col, (Uri)value);
 
-				if (value is ExcelHyperLink)
-				{
-					range._worksheet.SetValueInner(row, col, ((ExcelHyperLink)value).Display);
-				}
-				else
-				{
-					var v = range._worksheet.GetValueInner(row, col);
-					if (v == null || v.ToString() == "")
-					{
-						range._worksheet.SetValueInner(row, col, ((Uri)value).OriginalString);
-					}
-				}
-			}
-			else
-			{
-				range._worksheet._hyperLinks.SetValue(row, col, (Uri)null);
-				range._worksheet.SetValueInner(row, col, (Uri)null);
-			}
-		}
-		private static void Set_IsRichText(ExcelRangeBase range, object value, int row, int col)
-		{
-			range._worksheet._flags.SetFlagValue(row, col, (bool)value, CellFlags.RichText);
-		}
-		private static void Exists_Comment(ExcelRangeBase range, object value, int row, int col)
-		{
-			if (range._worksheet._commentsStore.Exists(row,col))
-			{
-				throw (new InvalidOperationException(string.Format("Cell {0} already contain a comment.", new ExcelCellAddress(row, col).Address)));
-			}
+                if (value is ExcelHyperLink)
+                {
+                    range._worksheet.SetValueInner(row, col, ((ExcelHyperLink)value).Display);
+                }
+                else
+                {
+                    var v = range._worksheet.GetValueInner(row, col);
+                    if (v == null || v.ToString() == "")
+                    {
+                        range._worksheet.SetValueInner(row, col, ((Uri)value).OriginalString);
+                    }
+                }
+            }
+            else
+            {
+                range._worksheet._hyperLinks.SetValue(row, col, (Uri)null);
+                range._worksheet.SetValueInner(row, col, (Uri)null);
+            }
+        }
+        private static void Set_IsRichText(ExcelRangeBase range, object value, int row, int col)
+        {
+            range._worksheet._flags.SetFlagValue(row, col, (bool)value, CellFlags.RichText);
+        }
+        private static void Exists_Comment(ExcelRangeBase range, object value, int row, int col)
+        {
+            if (range._worksheet._commentsStore.Exists(row,col))
+            {
+                throw (new InvalidOperationException(string.Format("Cell {0} already contain a comment.", new ExcelCellAddress(row, col).Address)));
+            }
 
-		}
-		private static void Set_Comment(ExcelRangeBase range, object value, int row, int col)
-		{
-			string[] v = (string[])value;
-			range._worksheet.Comments.Add(new ExcelRangeBase(range._worksheet, GetAddress(range._fromRow, range._fromCol)), v[0], v[1]);
-		}
-		#endregion
-		private void SetToSelectedRange()
-		{
-			if (_worksheet.View.SelectedRange == "")
-			{
-				Address = "A1";
-			}
-			else
-			{
-				Address = _worksheet.View.SelectedRange;
-			}
-		}
-		private void IsRangeValid(string type)
-		{
-			if (_fromRow <= 0)
-			{
-				if (_address == "")
-				{
-					SetToSelectedRange();
-				}
-				else
-				{
-					if (type == "")
-					{
-						throw (new InvalidOperationException(string.Format("Range is not valid for this operation: {0}", _address)));
-					}
-					else
-					{
-						throw (new InvalidOperationException(string.Format("Range is not valid for {0} : {1}", type, _address)));
-					}
-				}
-			}
-		}
+        }
+        private static void Set_Comment(ExcelRangeBase range, object value, int row, int col)
+        {
+            string[] v = (string[])value;
+            range._worksheet.Comments.Add(new ExcelRangeBase(range._worksheet, GetAddress(range._fromRow, range._fromCol)), v[0], v[1]);
+        }
+        #endregion
+        private void SetToSelectedRange()
+        {
+            if (_worksheet.View.SelectedRange == "")
+            {
+                Address = "A1";
+            }
+            else
+            {
+                Address = _worksheet.View.SelectedRange;
+            }
+        }
+        private void IsRangeValid(string type)
+        {
+            if (_fromRow <= 0)
+            {
+                if (_address == "")
+                {
+                    SetToSelectedRange();
+                }
+                else
+                {
+                    if (type == "")
+                    {
+                        throw (new InvalidOperationException(string.Format("Range is not valid for this operation: {0}", _address)));
+                    }
+                    else
+                    {
+                        throw (new InvalidOperationException(string.Format("Range is not valid for {0} : {1}", type, _address)));
+                    }
+                }
+            }
+        }
         internal void UpdateAddress(string address)
         {
             throw new NotImplementedException();
@@ -402,10 +402,10 @@ namespace OfficeOpenXml
         /// The styleobject for the range.
         /// </summary>
         public ExcelStyle Style
-		{
-			get
-			{
-				IsRangeValid("styling");
+        {
+            get
+            {
+                IsRangeValid("styling");
                 int s=0;
                 if(!_worksheet.ExistsStyleInner(_fromRow,_fromCol, ref s)) //Cell exists
                 {
@@ -422,18 +422,18 @@ namespace OfficeOpenXml
                         }                        
                     }
                 }
-				return _worksheet.Workbook.Styles.GetStyleObject(s, _worksheet.PositionID, Address);
-			}
-		}
-		/// <summary>
-		/// The named style
-		/// </summary>
-		public string StyleName
-		{
-			get
-			{
-				IsRangeValid("styling");
-				int  xfId;
+                return _worksheet.Workbook.Styles.GetStyleObject(s, _worksheet.PositionID, Address);
+            }
+        }
+        /// <summary>
+        /// The named style
+        /// </summary>
+        public string StyleName
+        {
+            get
+            {
+                IsRangeValid("styling");
+                int  xfId;
                 if (_fromRow == 1 && _toRow == ExcelPackage.MaxRows)
                 {
                     xfId=GetColumnStyle(_fromCol);
@@ -475,23 +475,23 @@ namespace OfficeOpenXml
                 }
                 
                 return "";
-			}
-			set
-			{
-				_styleID = _worksheet.Workbook.Styles.GetStyleIdFromName(value);
+            }
+            set
+            {
+                _styleID = _worksheet.Workbook.Styles.GetStyleIdFromName(value);
                 int col = _fromCol;
                 if (_fromRow == 1 && _toRow == ExcelPackage.MaxRows)    //Full column
-				{
-					ExcelColumn column;
+                {
+                    ExcelColumn column;
                     var c = _worksheet.GetValue(0, _fromCol);
                     if (c==null)
-					{
+                    {
                         column = _worksheet.Column(_fromCol);
-					}
-					else
-					{
+                    }
+                    else
+                    {
                         column = (ExcelColumn)c;
-					}
+                    }
 
                     column.StyleName = value;
                     column.StyleID = _styleID;
@@ -545,7 +545,7 @@ namespace OfficeOpenXml
                             }
                         }
                     }
-				}
+                }
                 else if (_fromCol == 1 && _toCol == ExcelPackage.MaxColumns) //FullRow
                 {
                     for (int r = _fromRow; r <= _toRow; r++)
@@ -573,8 +573,8 @@ namespace OfficeOpenXml
                         _worksheet.SetStyleInner(cells.Row, cells.Column, _styleID);
                     }
                 }
-			}
-		}
+            }
+        }
 
         private int GetColumnStyle(int col)
         {
@@ -597,15 +597,15 @@ namespace OfficeOpenXml
             }
             return 0;
         }
-		/// <summary>
-		/// The style ID. 
-		/// It is not recomended to use this one. Use Named styles as an alternative.
-		/// If you do, make sure that you use the Style.UpdateXml() method to update any new styles added to the workbook.
-		/// </summary>
-		public int StyleID
-		{
-			get
-			{
+        /// <summary>
+        /// The style ID. 
+        /// It is not recomended to use this one. Use Named styles as an alternative.
+        /// If you do, make sure that you use the Style.UpdateXml() method to update any new styles added to the workbook.
+        /// </summary>
+        public int StyleID
+        {
+            get
+            {
                 int s=0;
                 if(!_worksheet.ExistsStyleInner(_fromRow, _fromCol, ref s))
                 {
@@ -615,252 +615,252 @@ namespace OfficeOpenXml
                     }
                 }
                 return s;
-			}
-			set
-			{
-				_changePropMethod(this, _setStyleIdDelegate, value);
-			}
-		}
-		/// <summary>
-		/// Set the range to a specific value
-		/// </summary>
-		public object Value
-		{
-			get
-			{
-				if (IsName)
-				{
-					if (_worksheet == null)
-					{
-						return _workbook._names[_address].NameValue;
-					}
-					else
-					{
-						return _worksheet.Names[_address].NameValue; 
-					}
-				}
-				else
-				{
-					if (_fromRow == _toRow && _fromCol == _toCol)
-					{
-						return _worksheet.GetValue(_fromRow, _fromCol);
-					}
-					else
-					{
-						return GetValueArray();
-					}
-				}
-			}
-			set
-			{
-				if (IsName)
-				{
-					if (_worksheet == null)
-					{
-						_workbook._names[_address].NameValue = value;
-					}
-					else
-					{
-						_worksheet.Names[_address].NameValue = value;
-					}
-				}
-				else
-				{
-					_changePropMethod(this, _setValueDelegate, value);
-				}
-			}
-		}
+            }
+            set
+            {
+                _changePropMethod(this, _setStyleIdDelegate, value);
+            }
+        }
+        /// <summary>
+        /// Set the range to a specific value
+        /// </summary>
+        public object Value
+        {
+            get
+            {
+                if (IsName)
+                {
+                    if (_worksheet == null)
+                    {
+                        return _workbook._names[_address].NameValue;
+                    }
+                    else
+                    {
+                        return _worksheet.Names[_address].NameValue; 
+                    }
+                }
+                else
+                {
+                    if (_fromRow == _toRow && _fromCol == _toCol)
+                    {
+                        return _worksheet.GetValue(_fromRow, _fromCol);
+                    }
+                    else
+                    {
+                        return GetValueArray();
+                    }
+                }
+            }
+            set
+            {
+                if (IsName)
+                {
+                    if (_worksheet == null)
+                    {
+                        _workbook._names[_address].NameValue = value;
+                    }
+                    else
+                    {
+                        _worksheet.Names[_address].NameValue = value;
+                    }
+                }
+                else
+                {
+                    _changePropMethod(this, _setValueDelegate, value);
+                }
+            }
+        }
 
-		private bool IsInfinityValue(object value)
-		{
-			double? valueAsDouble = value as double?;
+        private bool IsInfinityValue(object value)
+        {
+            double? valueAsDouble = value as double?;
 
-			if(valueAsDouble.HasValue && 
-				(double.IsNegativeInfinity(valueAsDouble.Value) || double.IsPositiveInfinity(valueAsDouble.Value)))
-			{
-				return true;
-			}
+            if(valueAsDouble.HasValue && 
+                (double.IsNegativeInfinity(valueAsDouble.Value) || double.IsPositiveInfinity(valueAsDouble.Value)))
+            {
+                return true;
+            }
 
-			return false;
-		}
+            return false;
+        }
 
-		private object GetValueArray()
-		{
-			ExcelAddressBase addr;
-			if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows && _toCol == ExcelPackage.MaxColumns)
-			{
-				addr = _worksheet.Dimension;
-				if (addr == null) return null;
-			}
-			else
-			{
-				addr = this;
-			}
-			object[,] v = new object[addr._toRow - addr._fromRow + 1, addr._toCol - addr._fromCol + 1];
+        private object GetValueArray()
+        {
+            ExcelAddressBase addr;
+            if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows && _toCol == ExcelPackage.MaxColumns)
+            {
+                addr = _worksheet.Dimension;
+                if (addr == null) return null;
+            }
+            else
+            {
+                addr = this;
+            }
+            object[,] v = new object[addr._toRow - addr._fromRow + 1, addr._toCol - addr._fromCol + 1];
 
-			for (int col = addr._fromCol; col <= addr._toCol; col++)
-			{
-				for (int row = addr._fromRow; row <= addr._toRow; row++)
-				{
+            for (int col = addr._fromCol; col <= addr._toCol; col++)
+            {
+                for (int row = addr._fromRow; row <= addr._toRow; row++)
+                {
                     object o = null;
-					if (_worksheet.ExistsValueInner(row, col, ref o))
-					{
+                    if (_worksheet.ExistsValueInner(row, col, ref o))
+                    {
                         if (_worksheet._flags.GetFlagValue(row, col, CellFlags.RichText))
-						{
-							v[row - addr._fromRow, col - addr._fromCol] = GetRichText(row, col).Text;
-						}
-						else
-						{
-							v[row - addr._fromRow, col - addr._fromCol] = o;
-						}
-					}
-				}
-			}
-			return v;
-		}
-		private ExcelAddressBase GetAddressDim(ExcelRangeBase addr)
-		{
-			int fromRow, fromCol, toRow, toCol;
-			var d = _worksheet.Dimension;
-			fromRow = addr._fromRow < d._fromRow ? d._fromRow : addr._fromRow;
-			fromCol = addr._fromCol < d._fromCol ? d._fromCol : addr._fromCol;
+                        {
+                            v[row - addr._fromRow, col - addr._fromCol] = GetRichText(row, col).Text;
+                        }
+                        else
+                        {
+                            v[row - addr._fromRow, col - addr._fromCol] = o;
+                        }
+                    }
+                }
+            }
+            return v;
+        }
+        private ExcelAddressBase GetAddressDim(ExcelRangeBase addr)
+        {
+            int fromRow, fromCol, toRow, toCol;
+            var d = _worksheet.Dimension;
+            fromRow = addr._fromRow < d._fromRow ? d._fromRow : addr._fromRow;
+            fromCol = addr._fromCol < d._fromCol ? d._fromCol : addr._fromCol;
 
-			toRow = addr._toRow > d._toRow ? d._toRow : addr._toRow;
-			toCol = addr._toCol > d._toCol ? d._toCol : addr._toCol;
+            toRow = addr._toRow > d._toRow ? d._toRow : addr._toRow;
+            toCol = addr._toCol > d._toCol ? d._toCol : addr._toCol;
 
-			if (addr._fromRow == fromRow && addr._fromCol == fromCol && addr._toRow == toRow && addr._toCol == _toCol)
-			{
-				return addr;
-			}
-			else
-			{
-				if (_fromRow > _toRow || _fromCol > _toCol)
-				{
-					return null;
-				}
-				else
-				{
-					return new ExcelAddressBase(fromRow, fromCol, toRow, toCol);
-				}
-			}
-		}
+            if (addr._fromRow == fromRow && addr._fromCol == fromCol && addr._toRow == toRow && addr._toCol == _toCol)
+            {
+                return addr;
+            }
+            else
+            {
+                if (_fromRow > _toRow || _fromCol > _toCol)
+                {
+                    return null;
+                }
+                else
+                {
+                    return new ExcelAddressBase(fromRow, fromCol, toRow, toCol);
+                }
+            }
+        }
 
-		private object GetSingleValue()
-		{
-			if (IsRichText)
-			{
-				return RichText.Text;
-			}
-			else
-			{
-				return _worksheet.GetValueInner(_fromRow, _fromCol);
-			}
-		}
-		/// <summary>
-		/// Returns the formatted value.
-		/// </summary>
-		public string Text
-		{
-			get
-			{
-				return GetFormattedText(false);
-			}
-		}
-		/// <summary>
-		/// Set the column width from the content of the range. The minimum width is the value of the ExcelWorksheet.defaultColumnWidth property.
-		/// Note: Cells containing formulas are ignored since EPPlus don't have a calculation engine.
-		/// Wrapped and merged cells are also ignored.
-		/// </summary>
-		public void AutoFitColumns()
-		{
-			AutoFitColumns(_worksheet.DefaultColWidth);
-		}
+        private object GetSingleValue()
+        {
+            if (IsRichText)
+            {
+                return RichText.Text;
+            }
+            else
+            {
+                return _worksheet.GetValueInner(_fromRow, _fromCol);
+            }
+        }
+        /// <summary>
+        /// Returns the formatted value.
+        /// </summary>
+        public string Text
+        {
+            get
+            {
+                return GetFormattedText(false);
+            }
+        }
+        /// <summary>
+        /// Set the column width from the content of the range. The minimum width is the value of the ExcelWorksheet.defaultColumnWidth property.
+        /// Note: Cells containing formulas are ignored since EPPlus don't have a calculation engine.
+        /// Wrapped and merged cells are also ignored.
+        /// </summary>
+        public void AutoFitColumns()
+        {
+            AutoFitColumns(_worksheet.DefaultColWidth);
+        }
 
-		/// <summary>
-		/// Set the column width from the content of the range.
-		/// Note: Cells containing formulas are ignored if no calculation is made.
-		///       Wrapped and merged cells are also ignored.
-		/// </summary>
+        /// <summary>
+        /// Set the column width from the content of the range.
+        /// Note: Cells containing formulas are ignored if no calculation is made.
+        ///       Wrapped and merged cells are also ignored.
+        /// </summary>
         /// <remarks>This method will not work if you run in an environment that does not support GDI</remarks>
-		/// <param name="MinimumWidth">Minimum column width</param>
-		public void AutoFitColumns(double MinimumWidth)
-		{
-		    AutoFitColumns(MinimumWidth, double.MaxValue);
-		}
+        /// <param name="MinimumWidth">Minimum column width</param>
+        public void AutoFitColumns(double MinimumWidth)
+        {
+            AutoFitColumns(MinimumWidth, double.MaxValue);
+        }
 
-	    /// <summary>
-	    /// Set the column width from the content of the range.
+        /// <summary>
+        /// Set the column width from the content of the range.
         /// Note: Cells containing formulas are ignored if no calculation is made.
         ///       Wrapped and merged cells are also ignored.
         ///      Hidden columns are left hidden.
-	    /// </summary>
-	    /// <param name="MinimumWidth">Minimum column width</param>
-	    /// <param name="MaximumWidth">Maximum column width</param>
-	    public void AutoFitColumns(double MinimumWidth, double MaximumWidth)
-		{
+        /// </summary>
+        /// <param name="MinimumWidth">Minimum column width</param>
+        /// <param name="MaximumWidth">Maximum column width</param>
+        public void AutoFitColumns(double MinimumWidth, double MaximumWidth)
+        {
             if (_worksheet.Dimension == null)
             {
                 return;
             }
             if (_fromCol < 1 || _fromRow < 1)
-			{
-				SetToSelectedRange();
-			}
+            {
+                SetToSelectedRange();
+            }
             var fontCache = new Dictionary<int, Font>();
 
-	        bool doAdjust = _worksheet._package.DoAdjustDrawings;
-			_worksheet._package.DoAdjustDrawings = false;
-			var drawWidths = _worksheet.Drawings.GetDrawingWidths();
+            bool doAdjust = _worksheet._package.DoAdjustDrawings;
+            _worksheet._package.DoAdjustDrawings = false;
+            var drawWidths = _worksheet.Drawings.GetDrawingWidths();
 
-			var fromCol = _fromCol > _worksheet.Dimension._fromCol ? _fromCol : _worksheet.Dimension._fromCol;
-			var toCol = _toCol < _worksheet.Dimension._toCol ? _toCol : _worksheet.Dimension._toCol;
+            var fromCol = _fromCol > _worksheet.Dimension._fromCol ? _fromCol : _worksheet.Dimension._fromCol;
+            var toCol = _toCol < _worksheet.Dimension._toCol ? _toCol : _worksheet.Dimension._toCol;
 
             if (fromCol > toCol) return; //Issue 15383
 
             if (Addresses == null)
-			{
-				SetMinWidth(MinimumWidth, fromCol, toCol);
-			}
-			else
-			{
-				foreach (var addr in Addresses)
-				{
-					fromCol = addr._fromCol > _worksheet.Dimension._fromCol ? addr._fromCol : _worksheet.Dimension._fromCol;
-					toCol = addr._toCol < _worksheet.Dimension._toCol ? addr._toCol : _worksheet.Dimension._toCol;
+            {
+                SetMinWidth(MinimumWidth, fromCol, toCol);
+            }
+            else
+            {
+                foreach (var addr in Addresses)
+                {
+                    fromCol = addr._fromCol > _worksheet.Dimension._fromCol ? addr._fromCol : _worksheet.Dimension._fromCol;
+                    toCol = addr._toCol < _worksheet.Dimension._toCol ? addr._toCol : _worksheet.Dimension._toCol;
                     SetMinWidth(MinimumWidth, fromCol, toCol);
                 }
-			}
+            }
 
-			//Get any autofilter to widen these columns
-			var afAddr = new List<ExcelAddressBase>();
-			if (_worksheet.AutoFilterAddress != null)
-			{
-				afAddr.Add(new ExcelAddressBase(    _worksheet.AutoFilterAddress._fromRow,
-													_worksheet.AutoFilterAddress._fromCol,
-													_worksheet.AutoFilterAddress._fromRow,
-													_worksheet.AutoFilterAddress._toCol));
-				afAddr[afAddr.Count - 1]._ws = WorkSheet;
-			}
-			foreach (var tbl in _worksheet.Tables)
-			{
-				if (tbl.AutoFilterAddress != null)
-				{
-					afAddr.Add(new ExcelAddressBase(tbl.AutoFilterAddress._fromRow,
-																			tbl.AutoFilterAddress._fromCol,
-																			tbl.AutoFilterAddress._fromRow,
-																			tbl.AutoFilterAddress._toCol));
-					afAddr[afAddr.Count - 1]._ws = WorkSheet;
-				}
-			}
+            //Get any autofilter to widen these columns
+            var afAddr = new List<ExcelAddressBase>();
+            if (_worksheet.AutoFilterAddress != null)
+            {
+                afAddr.Add(new ExcelAddressBase(    _worksheet.AutoFilterAddress._fromRow,
+                                                    _worksheet.AutoFilterAddress._fromCol,
+                                                    _worksheet.AutoFilterAddress._fromRow,
+                                                    _worksheet.AutoFilterAddress._toCol));
+                afAddr[afAddr.Count - 1]._ws = WorkSheet;
+            }
+            foreach (var tbl in _worksheet.Tables)
+            {
+                if (tbl.AutoFilterAddress != null)
+                {
+                    afAddr.Add(new ExcelAddressBase(tbl.AutoFilterAddress._fromRow,
+                                                                            tbl.AutoFilterAddress._fromCol,
+                                                                            tbl.AutoFilterAddress._fromRow,
+                                                                            tbl.AutoFilterAddress._toCol));
+                    afAddr[afAddr.Count - 1]._ws = WorkSheet;
+                }
+            }
 
-			var styles = _worksheet.Workbook.Styles;
-			var nf = styles.Fonts[styles.CellXfs[0].FontId];
-			var fs = FontStyle.Regular;
-			if (nf.Bold) fs |= FontStyle.Bold;
-			if (nf.UnderLine) fs |= FontStyle.Underline;
-			if (nf.Italic) fs |= FontStyle.Italic;
-			if (nf.Strike) fs |= FontStyle.Strikeout;
-			var nfont = new Font(nf.Name, nf.Size, fs);
+            var styles = _worksheet.Workbook.Styles;
+            var nf = styles.Fonts[styles.CellXfs[0].FontId];
+            var fs = FontStyle.Regular;
+            if (nf.Bold) fs |= FontStyle.Bold;
+            if (nf.UnderLine) fs |= FontStyle.Underline;
+            if (nf.Italic) fs |= FontStyle.Italic;
+            if (nf.Strike) fs |= FontStyle.Strikeout;
+            var nfont = new Font(nf.Name, nf.Size, fs);
             
             var normalSize = Convert.ToSingle(ExcelWorkbook.GetWidthPixels(nf.Name, nf.Size));
 
@@ -879,30 +879,30 @@ namespace OfficeOpenXml
             }
 
             foreach (var cell in this)
-			{
+            {
                 if (_worksheet.Column(cell.Start.Column).Hidden)    //Issue 15338
                     continue;
 
                 if (cell.Merge == true || cell.Style.WrapText) continue;
-				var fntID = styles.CellXfs[cell.StyleID].FontId;
-				Font f;
-				if (fontCache.ContainsKey(fntID))
-				{
-					f = fontCache[fntID];
-				}
-				else
-				{
-					var fnt = styles.Fonts[fntID];
-					fs = FontStyle.Regular;
-					if (fnt.Bold) fs |= FontStyle.Bold;
-					if (fnt.UnderLine) fs |= FontStyle.Underline;
-					if (fnt.Italic) fs |= FontStyle.Italic;
-					if (fnt.Strike) fs |= FontStyle.Strikeout;
+                var fntID = styles.CellXfs[cell.StyleID].FontId;
+                Font f;
+                if (fontCache.ContainsKey(fntID))
+                {
+                    f = fontCache[fntID];
+                }
+                else
+                {
+                    var fnt = styles.Fonts[fntID];
+                    fs = FontStyle.Regular;
+                    if (fnt.Bold) fs |= FontStyle.Bold;
+                    if (fnt.UnderLine) fs |= FontStyle.Underline;
+                    if (fnt.Italic) fs |= FontStyle.Italic;
+                    if (fnt.Strike) fs |= FontStyle.Strikeout;
                     f = new Font(fnt.Name, fnt.Size, fs);
                     //f = new wm.Typeface(new System.Windows.Media.FontFamily(fnt.Name), fnt.Italic ? System.Windows.FontStyles.Italic : System.Windows.FontStyles.Normal, fnt.Bold ? System.Windows.FontWeights.Bold : System.Windows.FontWeights.Normal, System.Windows.FontStretches.Normal);
 
                     fontCache.Add(fntID, f);
-				}
+                }
                 var ind = styles.CellXfs[cell.StyleID].Indent;
                 var textForWidth = cell.TextForWidth;
                 var t = textForWidth + (ind > 0 && !string.IsNullOrEmpty(textForWidth) ? new string('_',ind) : "");
@@ -932,24 +932,24 @@ namespace OfficeOpenXml
                     //width= (((size.Width-size.Height) * Math.Abs(Math.Cos(Math.PI * r / 180.0)) + size.Height) +15) / normalSize;
                 }
 
-				foreach (var a in afAddr)
-				{
-					if (a.Collide(cell) != eAddressCollition.No)
-					{
+                foreach (var a in afAddr)
+                {
+                    if (a.Collide(cell) != eAddressCollition.No)
+                    {
                         //width += 2.8;
                         width += 2.25;
                         break;
-					}
-				}
+                    }
+                }
 
-				if (width > _worksheet.Column(cell._fromCol).Width)
-				{
-					_worksheet.Column(cell._fromCol).Width = width > MaximumWidth ? MaximumWidth : width;
-				}
-			}
-			_worksheet.Drawings.AdjustWidth(drawWidths);
-			_worksheet._package.DoAdjustDrawings = doAdjust;
-		}
+                if (width > _worksheet.Column(cell._fromCol).Width)
+                {
+                    _worksheet.Column(cell._fromCol).Width = width > MaximumWidth ? MaximumWidth : width;
+                }
+            }
+            _worksheet.Drawings.AdjustWidth(drawWidths);
+            _worksheet._package.DoAdjustDrawings = doAdjust;
+        }
 
         private void SetMinWidth(double minimumWidth, int fromCol, int toCol)
         {
@@ -976,130 +976,130 @@ namespace OfficeOpenXml
         }
 
         internal string TextForWidth
-		{
-			get
-			{
-				return GetFormattedText(true);
-			}
-		}
-		private string GetFormattedText(bool forWidthCalc)
-		{
-			object v = Value;
-			if (v == null) return "";
-			var styles = Worksheet.Workbook.Styles;
-			var nfID = styles.CellXfs[StyleID].NumberFormatId;
-			ExcelNumberFormatXml.ExcelFormatTranslator nf = null;
-			for (int i = 0; i < styles.NumberFormats.Count; i++)
-			{
-				if (nfID == styles.NumberFormats[i].NumFmtId)
-				{
-					nf = styles.NumberFormats[i].FormatTranslator;
-					break;
-				}
-			}
+        {
+            get
+            {
+                return GetFormattedText(true);
+            }
+        }
+        private string GetFormattedText(bool forWidthCalc)
+        {
+            object v = Value;
+            if (v == null) return "";
+            var styles = Worksheet.Workbook.Styles;
+            var nfID = styles.CellXfs[StyleID].NumberFormatId;
+            ExcelNumberFormatXml.ExcelFormatTranslator nf = null;
+            for (int i = 0; i < styles.NumberFormats.Count; i++)
+            {
+                if (nfID == styles.NumberFormats[i].NumFmtId)
+                {
+                    nf = styles.NumberFormats[i].FormatTranslator;
+                    break;
+                }
+            }
             if(nf==null)
             {
                 nf = styles.NumberFormats[0].FormatTranslator;  //nf should never be null. If so set to General, Issue 173
             }
 
-			string format, textFormat;
-			if (forWidthCalc)
-			{
-				format = nf.NetFormatForWidth;
-				textFormat = nf.NetTextFormatForWidth;
-			}
-			else
-			{
-				format = nf.NetFormat;
-				textFormat = nf.NetTextFormat;
-			}
+            string format, textFormat;
+            if (forWidthCalc)
+            {
+                format = nf.NetFormatForWidth;
+                textFormat = nf.NetTextFormatForWidth;
+            }
+            else
+            {
+                format = nf.NetFormat;
+                textFormat = nf.NetTextFormat;
+            }
 
             return FormatValue(v, nf, format, textFormat);
-		}
+        }
 
         internal static string FormatValue(object v, ExcelNumberFormatXml.ExcelFormatTranslator nf, string format, string textFormat)
         {
-			if (v is decimal || TypeCompat.IsPrimitive(v))
-			{
-				double d;
-				try
-				{
-					d = Convert.ToDouble(v);
-				}
-				catch
-				{
-					return "";
-				}
+            if (v is decimal || TypeCompat.IsPrimitive(v))
+            {
+                double d;
+                try
+                {
+                    d = Convert.ToDouble(v);
+                }
+                catch
+                {
+                    return "";
+                }
 
-				if (nf.DataType == ExcelNumberFormatXml.eFormatType.Number)
-				{
-					if (string.IsNullOrEmpty(nf.FractionFormat))
-					{
-						return d.ToString(format, nf.Culture);
-					}
-					else
-					{
-						return nf.FormatFraction(d);
-					}
-				}
-				else if (nf.DataType == ExcelNumberFormatXml.eFormatType.DateTime)
-				{
+                if (nf.DataType == ExcelNumberFormatXml.eFormatType.Number)
+                {
+                    if (string.IsNullOrEmpty(nf.FractionFormat))
+                    {
+                        return d.ToString(format, nf.Culture);
+                    }
+                    else
+                    {
+                        return nf.FormatFraction(d);
+                    }
+                }
+                else if (nf.DataType == ExcelNumberFormatXml.eFormatType.DateTime)
+                {
                     var date = DateTime.FromOADate(d);
                     //return date.ToString(format, nf.Culture);
                     return GetDateText(date, format, nf.Culture);
                 }
-			}
-			else if (v is DateTime)
-			{
-				if (nf.DataType == ExcelNumberFormatXml.eFormatType.DateTime)
-				{
+            }
+            else if (v is DateTime)
+            {
+                if (nf.DataType == ExcelNumberFormatXml.eFormatType.DateTime)
+                {
                     return GetDateText((DateTime)v, format, nf.Culture);
-				}
-				else
-				{
-					double d = ((DateTime)v).ToOADate();
-					if (string.IsNullOrEmpty(nf.FractionFormat))
-					{
-						return d.ToString(format, nf.Culture);
-					}
-					else
-					{
-						return nf.FormatFraction(d);
-					}
-				}
-			}
-			else if (v is TimeSpan)
-			{
-				if (nf.DataType == ExcelNumberFormatXml.eFormatType.DateTime)
-				{
+                }
+                else
+                {
+                    double d = ((DateTime)v).ToOADate();
+                    if (string.IsNullOrEmpty(nf.FractionFormat))
+                    {
+                        return d.ToString(format, nf.Culture);
+                    }
+                    else
+                    {
+                        return nf.FormatFraction(d);
+                    }
+                }
+            }
+            else if (v is TimeSpan)
+            {
+                if (nf.DataType == ExcelNumberFormatXml.eFormatType.DateTime)
+                {
                     return GetDateText(new DateTime(((TimeSpan)v).Ticks), format, nf.Culture);
                     //return new DateTime(((TimeSpan)v).Ticks).ToString(format, nf.Culture);
                 }
-				else
-				{
-					double d = new DateTime(0).Add((TimeSpan)v).ToOADate();
-					if (string.IsNullOrEmpty(nf.FractionFormat))
-					{
-						return d.ToString(format, nf.Culture);
-					}
-					else
-					{
-						return nf.FormatFraction(d);
-					}
-				}
-			}
-			else
-			{
-				if (textFormat == "")
-				{
-					return v.ToString();
-				}
-				else
-				{
-					return string.Format(textFormat, v);
-				}
-			}
-			return v.ToString();
+                else
+                {
+                    double d = new DateTime(0).Add((TimeSpan)v).ToOADate();
+                    if (string.IsNullOrEmpty(nf.FractionFormat))
+                    {
+                        return d.ToString(format, nf.Culture);
+                    }
+                    else
+                    {
+                        return nf.FormatFraction(d);
+                    }
+                }
+            }
+            else
+            {
+                if (textFormat == "")
+                {
+                    return v.ToString();
+                }
+                else
+                {
+                    return string.Format(textFormat, v);
+                }
+            }
+            return v.ToString();
 }
 
         private static string GetDateText(DateTime d, string format, CultureInfo culture)
@@ -1135,76 +1135,76 @@ namespace OfficeOpenXml
         /// Gets or sets a formula for a range.
         /// </summary>
         public string Formula
-		{
-			get
-			{
-				if (IsName)
-				{
-					if (_worksheet == null)
-					{
-						return _workbook._names[_address].NameFormula;
-					}
-					else
-					{
-						return _worksheet.Names[_address].NameFormula;
-					}
-				}
-				else
-				{
-					return _worksheet.GetFormula(_fromRow, _fromCol);                    
-				}
-			}
-			set
-			{
-				if (IsName)
-				{
-					if (_worksheet == null)
-					{
-						_workbook._names[_address].NameFormula = value;
-					}
-					else
-					{
-						_worksheet.Names[_address].NameFormula = value;
-					}
-				}
-				else
-				{
-					if(value==null || value.Trim()=="")
+        {
+            get
+            {
+                if (IsName)
+                {
+                    if (_worksheet == null)
+                    {
+                        return _workbook._names[_address].NameFormula;
+                    }
+                    else
+                    {
+                        return _worksheet.Names[_address].NameFormula;
+                    }
+                }
+                else
+                {
+                    return _worksheet.GetFormula(_fromRow, _fromCol);                    
+                }
+            }
+            set
+            {
+                if (IsName)
+                {
+                    if (_worksheet == null)
+                    {
+                        _workbook._names[_address].NameFormula = value;
+                    }
+                    else
+                    {
+                        _worksheet.Names[_address].NameFormula = value;
+                    }
+                }
+                else
+                {
+                    if(value==null || value.Trim()=="")
                     {
                         //Set the cells to null
                         Value = null;
                     }                    
                     else if (_fromRow == _toRow && _fromCol == _toCol)
-					{
-						Set_Formula(this, value, _fromRow, _fromCol);
-					}
-					else
-					{
-						Set_SharedFormula(this, value, this, false);
-						if (Addresses != null)
-						{
-							foreach (var address in Addresses)
-							{
-								Set_SharedFormula(this, value, address, false);
-							}
-						}
-					}
-				}
-			}
-		}
-		/// <summary>
-		/// Gets or Set a formula in R1C1 format.
-		/// </summary>
-		public string FormulaR1C1
-		{
-			get
-			{
-				IsRangeValid("FormulaR1C1");
-				return _worksheet.GetFormulaR1C1(_fromRow, _fromCol);
-			}
-			set
-			{
-				IsRangeValid("FormulaR1C1");
+                    {
+                        Set_Formula(this, value, _fromRow, _fromCol);
+                    }
+                    else
+                    {
+                        Set_SharedFormula(this, value, this, false);
+                        if (Addresses != null)
+                        {
+                            foreach (var address in Addresses)
+                            {
+                                Set_SharedFormula(this, value, address, false);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// Gets or Set a formula in R1C1 format.
+        /// </summary>
+        public string FormulaR1C1
+        {
+            get
+            {
+                IsRangeValid("FormulaR1C1");
+                return _worksheet.GetFormulaR1C1(_fromRow, _fromCol);
+            }
+            set
+            {
+                IsRangeValid("FormulaR1C1");
                 if (value.Length > 0 && value[0] == '=') value = value.Substring(1, value.Length - 1); // remove any starting equalsign.
 
                 if (value == null || value.Trim() == "")
@@ -1212,109 +1212,109 @@ namespace OfficeOpenXml
                     //Set the cells to null
                     _worksheet.Cells[ExcelCellBase.TranslateFromR1C1(value, _fromRow, _fromCol)].Value = null;    
                 }
-				else if (Addresses == null)
-				{
-					Set_SharedFormula(this, ExcelCellBase.TranslateFromR1C1(value, _fromRow, _fromCol), this, false);
-				}
-				else
-				{
-					Set_SharedFormula(this, ExcelCellBase.TranslateFromR1C1(value, _fromRow, _fromCol), new ExcelAddress(WorkSheet, FirstAddress), false);
-					foreach (var address in Addresses)
-					{
-						Set_SharedFormula(this, ExcelCellBase.TranslateFromR1C1(value, address.Start.Row, address.Start.Column), address, false);
-					}
-				}
-			}
-		}
-		/// <summary>
-		/// Set the hyperlink property for a range of cells
-		/// </summary>
-		public Uri Hyperlink
-		{
-			get
-			{
-				IsRangeValid("formulaR1C1");
-				return _worksheet._hyperLinks.GetValue(_fromRow, _fromCol);
-			}
-			set
-			{
-				_changePropMethod(this, _setHyperLinkDelegate, value);
-			}
-		}
-		/// <summary>
-		/// If the cells in the range are merged.
-		/// </summary>
-		public bool Merge
-		{
-			get
-			{
-				IsRangeValid("merging");
-				for (int col = _fromCol; col <= _toCol; col++)
-				{
-					for (int row = _fromRow; row <= _toRow; row++)
-					{
+                else if (Addresses == null)
+                {
+                    Set_SharedFormula(this, ExcelCellBase.TranslateFromR1C1(value, _fromRow, _fromCol), this, false);
+                }
+                else
+                {
+                    Set_SharedFormula(this, ExcelCellBase.TranslateFromR1C1(value, _fromRow, _fromCol), new ExcelAddress(WorkSheet, FirstAddress), false);
+                    foreach (var address in Addresses)
+                    {
+                        Set_SharedFormula(this, ExcelCellBase.TranslateFromR1C1(value, address.Start.Row, address.Start.Column), address, false);
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// Set the hyperlink property for a range of cells
+        /// </summary>
+        public Uri Hyperlink
+        {
+            get
+            {
+                IsRangeValid("formulaR1C1");
+                return _worksheet._hyperLinks.GetValue(_fromRow, _fromCol);
+            }
+            set
+            {
+                _changePropMethod(this, _setHyperLinkDelegate, value);
+            }
+        }
+        /// <summary>
+        /// If the cells in the range are merged.
+        /// </summary>
+        public bool Merge
+        {
+            get
+            {
+                IsRangeValid("merging");
+                for (int col = _fromCol; col <= _toCol; col++)
+                {
+                    for (int row = _fromRow; row <= _toRow; row++)
+                    {
                         if(_worksheet.MergedCells[row, col]==null)
                         {
                             return false;
                         }
-					}
-				}
-				return true;
-			}
-			set
-			{
-				IsRangeValid("merging");
+                    }
+                }
+                return true;
+            }
+            set
+            {
+                IsRangeValid("merging");
                 _worksheet.MergedCells.Clear(this);
                 if (value)
-			    {
+                {
                     _worksheet.MergedCells.Add(new ExcelAddressBase(FirstAddress), true);
-			        if (Addresses != null)
-			        {
-			            foreach (var address in Addresses)
-			            {
+                    if (Addresses != null)
+                    {
+                        foreach (var address in Addresses)
+                        {
                             _worksheet.MergedCells.Clear(address); //Fixes issue 15482
                             _worksheet.MergedCells.Add(address, true);
-			            }
-			        }
-			    }
-			    else
-			    {
+                        }
+                    }
+                }
+                else
+                {
                     if (Addresses != null)
-			        {
-			            foreach (var address in Addresses)
-			            {
+                    {
+                        foreach (var address in Addresses)
+                        {
                             _worksheet.MergedCells.Clear(address); ;
-			            }
-			        }
-			        
-			    }
-			}
-		}
-		/// <summary>
-		/// Set an autofilter for the range
-		/// </summary>
-		public bool AutoFilter
-		{
-			get
-			{
-				IsRangeValid("autofilter");
-				ExcelAddressBase address = _worksheet.AutoFilterAddress;
-				if (address == null) return false;
-				if (_fromRow >= address.Start.Row
-						&&
-						_toRow <= address.End.Row
-						&&
-						_fromCol >= address.Start.Column
-						&&
-						_toCol <= address.End.Column)
-				{
-					return true;
-				}
-				return false;
-			}
-			set
-			{
-				IsRangeValid("autofilter");
+                        }
+                    }
+                    
+                }
+            }
+        }
+        /// <summary>
+        /// Set an autofilter for the range
+        /// </summary>
+        public bool AutoFilter
+        {
+            get
+            {
+                IsRangeValid("autofilter");
+                ExcelAddressBase address = _worksheet.AutoFilterAddress;
+                if (address == null) return false;
+                if (_fromRow >= address.Start.Row
+                        &&
+                        _toRow <= address.End.Row
+                        &&
+                        _fromCol >= address.Start.Column
+                        &&
+                        _toCol <= address.End.Column)
+                {
+                    return true;
+                }
+                return false;
+            }
+            set
+            {
+                IsRangeValid("autofilter");
                 if (_worksheet.AutoFilterAddress != null)
                 {
                     var c = this.Collide(_worksheet.AutoFilterAddress);
@@ -1337,83 +1337,83 @@ namespace OfficeOpenXml
                 {
                     _worksheet.AutoFilterAddress = null;
                 }
-			}
-		}
-		/// <summary>
-		/// If the value is in richtext format.
-		/// </summary>
-		public bool IsRichText
-		{
-			get
-			{
-				IsRangeValid("richtext");
-				return _worksheet._flags.GetFlagValue(_fromRow, _fromCol,CellFlags.RichText);
-			}
-			set
-			{
-				_changePropMethod(this, _setIsRichTextDelegate, value);
-			}
-		}
-		/// <summary>
-		/// Is the range a part of an Arrayformula
-		/// </summary>
-		public bool IsArrayFormula
-		{
-			get
-			{
-				IsRangeValid("arrayformulas");
+            }
+        }
+        /// <summary>
+        /// If the value is in richtext format.
+        /// </summary>
+        public bool IsRichText
+        {
+            get
+            {
+                IsRangeValid("richtext");
+                return _worksheet._flags.GetFlagValue(_fromRow, _fromCol,CellFlags.RichText);
+            }
+            set
+            {
+                _changePropMethod(this, _setIsRichTextDelegate, value);
+            }
+        }
+        /// <summary>
+        /// Is the range a part of an Arrayformula
+        /// </summary>
+        public bool IsArrayFormula
+        {
+            get
+            {
+                IsRangeValid("arrayformulas");
                 return _worksheet._flags.GetFlagValue(_fromRow, _fromCol, CellFlags.ArrayFormula);
-			}
-		}
-		protected ExcelRichTextCollection _rtc = null;
-		/// <summary>
-		/// Cell value is richtext formatted. 
-		/// Richtext-property only apply to the left-top cell of the range.
-		/// </summary>
-		public ExcelRichTextCollection RichText
-		{
-			get
-			{
-				IsRangeValid("richtext");
-				if (_rtc == null)
-				{
-					_rtc = GetRichText(_fromRow, _fromCol);
-				}
-				return _rtc;
-			}
-		}
+            }
+        }
+        protected ExcelRichTextCollection _rtc = null;
+        /// <summary>
+        /// Cell value is richtext formatted. 
+        /// Richtext-property only apply to the left-top cell of the range.
+        /// </summary>
+        public ExcelRichTextCollection RichText
+        {
+            get
+            {
+                IsRangeValid("richtext");
+                if (_rtc == null)
+                {
+                    _rtc = GetRichText(_fromRow, _fromCol);
+                }
+                return _rtc;
+            }
+        }
 
-		private ExcelRichTextCollection GetRichText(int row, int col)
-		{
-			XmlDocument xml = new XmlDocument();
+        private ExcelRichTextCollection GetRichText(int row, int col)
+        {
+            XmlDocument xml = new XmlDocument();
             var v = _worksheet.GetValueInner(row, col);
             var isRt = _worksheet._flags.GetFlagValue(row, col, CellFlags.RichText);
             if (v != null)
-			{
-				if (isRt)
-				{
+            {
+                if (isRt)
+                {
                     XmlHelper.LoadXmlSafe(xml, "<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" >" + v.ToString() + "</d:si>", Encoding.UTF8);
-				}
-				else
-				{
-					xml.LoadXml("<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" ><d:r><d:t>" + OfficeOpenXml.Utils.ConvertUtil.ExcelEscapeString(v.ToString()) + "</d:t></d:r></d:si>");
-				}
-			}
-			else
-			{
-				xml.LoadXml("<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" />");
-			}
-			var rtc = new ExcelRichTextCollection(_worksheet.NameSpaceManager, xml.SelectSingleNode("d:si", _worksheet.NameSpaceManager), this);
-			return rtc;
-		}
-		/// <summary>
-		/// returns the comment object of the first cell in the range
-		/// </summary>
-		public ExcelComment Comment
-		{
-			get
-			{
-				IsRangeValid("comments");
+                }
+                else
+                {
+                    xml.LoadXml("<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" ><d:r><d:t>" + OfficeOpenXml.Utils.ConvertUtil.ExcelEscapeString(v.ToString()) + "</d:t></d:r></d:si>");
+                }
+            }
+            else
+            {
+                xml.LoadXml("<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" />");
+            }
+            var rtc = new ExcelRichTextCollection(_worksheet.NameSpaceManager, xml.SelectSingleNode("d:si", _worksheet.NameSpaceManager), this);
+            return rtc;
+        }
+        /// <summary>
+        /// returns the comment object of the first cell in the range
+        /// </summary>
+        public ExcelComment Comment
+        {
+            get
+            {
+                IsRangeValid("comments");
                 var i = -1;
                 if (_worksheet.Comments.Count > 0)
                 {
@@ -1422,55 +1422,55 @@ namespace OfficeOpenXml
                         return _worksheet._comments[i] as ExcelComment;
                     }
                 }
-				return null;
-			}
-		}
-		/// <summary>
-		/// WorkSheet object 
-		/// </summary>
-		public ExcelWorksheet Worksheet
-		{
-			get
-			{
-				return _worksheet;
-			}
-		}
-		/// <summary>
-		/// Address including sheetname
-		/// </summary>
-		public new string FullAddress
-		{
-			get
-			{
-				string fullAddress = GetFullAddress(_worksheet.Name, _address);
-				if (Addresses != null)
-				{
-					foreach (var a in Addresses)
-					{
-						fullAddress += "," + GetFullAddress(_worksheet.Name, a.Address); ;
-					}
-				}
-				return fullAddress;
-			}
-		}
-		/// <summary>
-		/// Address including sheetname
-		/// </summary>
-		public string FullAddressAbsolute
-		{
-			get
-			{
-				string wbwsRef = string.IsNullOrEmpty(base._wb) ? base._ws : "[" + base._wb.Replace("'", "''") + "]" + _ws;
+                return null;
+            }
+        }
+        /// <summary>
+        /// WorkSheet object 
+        /// </summary>
+        public ExcelWorksheet Worksheet
+        {
+            get
+            {
+                return _worksheet;
+            }
+        }
+        /// <summary>
+        /// Address including sheetname
+        /// </summary>
+        public new string FullAddress
+        {
+            get
+            {
+                string fullAddress = GetFullAddress(_worksheet.Name, _address);
+                if (Addresses != null)
+                {
+                    foreach (var a in Addresses)
+                    {
+                        fullAddress += "," + GetFullAddress(_worksheet.Name, a.Address); ;
+                    }
+                }
+                return fullAddress;
+            }
+        }
+        /// <summary>
+        /// Address including sheetname
+        /// </summary>
+        public string FullAddressAbsolute
+        {
+            get
+            {
+                string wbwsRef = string.IsNullOrEmpty(base._wb) ? base._ws : "[" + base._wb.Replace("'", "''") + "]" + _ws;
                 string fullAddress;
-				if (Addresses == null)
+                if (Addresses == null)
                 {
                     fullAddress = GetFullAddress(wbwsRef, GetAddress(_fromRow, _fromCol, _toRow, _toCol, true));
                 }
                 else
-				{
+                {
                     fullAddress = "";
                     foreach (var a in Addresses)
-					{
+                    {
                         if (fullAddress != "") fullAddress += ",";
                         if (a.Address == "#REF!")
                         {
@@ -1480,11 +1480,11 @@ namespace OfficeOpenXml
                         {
                             fullAddress += GetFullAddress(wbwsRef, GetAddress(a.Start.Row, a.Start.Column, a.End.Row, a.End.Column, true)); 
                         }
-					}
-				}
-				return fullAddress;
-			}
-		}
+                    }
+                }
+                return fullAddress;
+            }
+        }
         /// <summary>
         /// Address including sheetname
         /// </summary>
@@ -1510,23 +1510,23 @@ namespace OfficeOpenXml
                 return fullAddress;
             }
         }
-		#endregion
-		#region Private Methods
-		/// <summary>
-		/// Set the value without altering the richtext property
-		/// </summary>
-		/// <param name="value">the value</param>
-		internal void SetValueRichText(object value)
-		{
-			if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows && _toCol == ExcelPackage.MaxColumns)  //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
-			{
+        #endregion
+        #region Private Methods
+        /// <summary>
+        /// Set the value without altering the richtext property
+        /// </summary>
+        /// <param name="value">the value</param>
+        internal void SetValueRichText(object value)
+        {
+            if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows && _toCol == ExcelPackage.MaxColumns)  //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
+            {
                 SetValue(value, 1, 1);
-			}
-			else
-			{
+            }
+            else
+            {
                 SetValue(value, _fromRow,_fromCol);
-			}
-		}
+            }
+        }
 
         private void SetValue(object value, int row, int col)
         {
@@ -1534,40 +1534,40 @@ namespace OfficeOpenXml
            // if (value is string) _worksheet._types.SetValue(row, col, "S"); else _worksheet._types.SetValue(row, col, "");
             _worksheet._formulas.SetValue(row, col, "");
         }
-		internal void SetSharedFormulaID(int id)
-		{
-			for (int col = _fromCol; col <= _toCol; col++)
-			{
-				for (int row = _fromRow; row <= _toRow; row++)
-				{
+        internal void SetSharedFormulaID(int id)
+        {
+            for (int col = _fromCol; col <= _toCol; col++)
+            {
+                for (int row = _fromRow; row <= _toRow; row++)
+                {
                     _worksheet._formulas.SetValue(row, col, id);
-				}
-			}
-		}
-		private void CheckAndSplitSharedFormula(ExcelAddressBase address)
-		{
+                }
+            }
+        }
+        private void CheckAndSplitSharedFormula(ExcelAddressBase address)
+        {
             for (int col = address._fromCol; col <= address._toCol; col++)
-			{
+            {
                 for (int row = address._fromRow; row <= address._toRow; row++)
-				{
+                {
                     var f = _worksheet._formulas.GetValue(row, col);
                     if (f is int && (int)f >= 0)
-					{
-						SplitFormulas(address);
-						return;
-					}
-				}
-			}
-		}
+                    {
+                        SplitFormulas(address);
+                        return;
+                    }
+                }
+            }
+        }
 
-		private void SplitFormulas(ExcelAddressBase address)
-		{
-			List<int> formulas = new List<int>();
+        private void SplitFormulas(ExcelAddressBase address)
+        {
+            List<int> formulas = new List<int>();
             for (int col = address._fromCol; col <= address._toCol; col++)
-			{
+            {
                 for (int row = address._fromRow; row <= address._toRow; row++)
-				{
-					var f = _worksheet._formulas.GetValue(row, col);
+                {
+                    var f = _worksheet._formulas.GetValue(row, col);
                     if (f is int)
                     {
                         int id = (int)f;
@@ -1581,31 +1581,31 @@ namespace OfficeOpenXml
                             formulas.Add(id);
                         }
                     }                    
-				}
-			}
+                }
+            }
 
-			foreach (int ix in formulas)
-			{
+            foreach (int ix in formulas)
+            {
                 SplitFormula(address, ix);
-			}
+            }
         
             ////Clear any formula references inside the refered range
             //_worksheet._formulas.Clear(address._fromRow, address._toRow, address._toRow - address._fromRow + 1, address._toCol - address.column + 1);
         }
 
-		private void SplitFormula(ExcelAddressBase address, int ix)
-		{
-			var f = _worksheet._sharedFormulas[ix];
-			var fRange = _worksheet.Cells[f.Address];
+        private void SplitFormula(ExcelAddressBase address, int ix)
+        {
+            var f = _worksheet._sharedFormulas[ix];
+            var fRange = _worksheet.Cells[f.Address];
             var collide = address.Collide(fRange);
 
             //The formula is inside the currenct range, remove it
-			if (collide == eAddressCollition.Equal || collide == eAddressCollition.Inside)
-			{
-				_worksheet._sharedFormulas.Remove(ix);
+            if (collide == eAddressCollition.Equal || collide == eAddressCollition.Inside)
+            {
+                _worksheet._sharedFormulas.Remove(ix);
                 return;
-				//fRange.SetSharedFormulaID(int.MinValue); 
-			}
+                //fRange.SetSharedFormulaID(int.MinValue); 
+            }
             var firstCellCollide = address.Collide(new ExcelAddressBase(fRange._fromRow, fRange._fromCol, fRange._fromRow, fRange._fromCol));
             if (collide == eAddressCollition.Partly && (firstCellCollide == eAddressCollition.Inside || firstCellCollide == eAddressCollition.Equal)) //Do we need to split? Only if the functions first row is inside the new range.
             {
@@ -1709,161 +1709,161 @@ namespace OfficeOpenXml
 
                 }
             }
-		}
-		private object ConvertData(ExcelTextFormat Format, string v, int col, bool isText)
-		{
-			if (isText && (Format.DataTypes == null || Format.DataTypes.Length < col)) return string.IsNullOrEmpty(v) ? null : v;
+        }
+        private object ConvertData(ExcelTextFormat Format, string v, int col, bool isText)
+        {
+            if (isText && (Format.DataTypes == null || Format.DataTypes.Length < col)) return string.IsNullOrEmpty(v) ? null : v;
 
-			double d;
-			DateTime dt;
-			if (Format.DataTypes == null || Format.DataTypes.Length <= col || Format.DataTypes[col] == eDataTypes.Unknown)
-			{
-				string v2 = v.EndsWith("%") ? v.Substring(0, v.Length - 1) : v;
-				if (double.TryParse(v2, NumberStyles.Any, Format.Culture, out d))
-				{
-					if (v2 == v)
-					{
-						return d;
-					}
-					else
-					{
-						return d / 100;
-					}
-				}
-				if (DateTime.TryParse(v, Format.Culture, DateTimeStyles.None, out dt))
-				{
-					return dt;
-				}
-				else
-				{
-					return string.IsNullOrEmpty(v) ? null : v; ;
-				}
-			}
-			else
-			{
-				switch (Format.DataTypes[col])
-				{
-					case eDataTypes.Number:
-						if (double.TryParse(v, NumberStyles.Any, Format.Culture, out d))
-						{
-							return d;
-						}
-						else
-						{
-							return v;
-						}
-					case eDataTypes.DateTime:
-						if (DateTime.TryParse(v, Format.Culture, DateTimeStyles.None, out dt))
-						{
-							return dt;
-						}
-						else
-						{
-							return v;
-						}
-					case eDataTypes.Percent:
-						string v2 = v.EndsWith("%") ? v.Substring(0, v.Length - 1) : v;
-						if (double.TryParse(v2, NumberStyles.Any, Format.Culture, out d))
-						{
-							return d / 100;
-						}
-						else
-						{
-							return v;
-						}
+            double d;
+            DateTime dt;
+            if (Format.DataTypes == null || Format.DataTypes.Length <= col || Format.DataTypes[col] == eDataTypes.Unknown)
+            {
+                string v2 = v.EndsWith("%") ? v.Substring(0, v.Length - 1) : v;
+                if (double.TryParse(v2, NumberStyles.Any, Format.Culture, out d))
+                {
+                    if (v2 == v)
+                    {
+                        return d;
+                    }
+                    else
+                    {
+                        return d / 100;
+                    }
+                }
+                if (DateTime.TryParse(v, Format.Culture, DateTimeStyles.None, out dt))
+                {
+                    return dt;
+                }
+                else
+                {
+                    return string.IsNullOrEmpty(v) ? null : v; ;
+                }
+            }
+            else
+            {
+                switch (Format.DataTypes[col])
+                {
+                    case eDataTypes.Number:
+                        if (double.TryParse(v, NumberStyles.Any, Format.Culture, out d))
+                        {
+                            return d;
+                        }
+                        else
+                        {
+                            return v;
+                        }
+                    case eDataTypes.DateTime:
+                        if (DateTime.TryParse(v, Format.Culture, DateTimeStyles.None, out dt))
+                        {
+                            return dt;
+                        }
+                        else
+                        {
+                            return v;
+                        }
+                    case eDataTypes.Percent:
+                        string v2 = v.EndsWith("%") ? v.Substring(0, v.Length - 1) : v;
+                        if (double.TryParse(v2, NumberStyles.Any, Format.Culture, out d))
+                        {
+                            return d / 100;
+                        }
+                        else
+                        {
+                            return v;
+                        }
                     case eDataTypes.String:
                         return v;
                     default:
-						return string.IsNullOrEmpty(v) ? null : v;
+                        return string.IsNullOrEmpty(v) ? null : v;
 
-				}
-			}
-		}
-		#endregion
-		#region Public Methods
-		#region ConditionalFormatting
-		/// <summary>
-		/// Conditional Formatting for this range.
-		/// </summary>
-		public IRangeConditionalFormatting ConditionalFormatting
-		{
-			get
-			{
-				return new RangeConditionalFormatting(_worksheet, new ExcelAddress(Address));
-			}
-		}
-		#endregion
-		#region DataValidation
-		/// <summary>
-		/// Data validation for this range.
-		/// </summary>
-		public IRangeDataValidation DataValidation
-		{
-			get
-			{
+                }
+            }
+        }
+        #endregion
+        #region Public Methods
+        #region ConditionalFormatting
+        /// <summary>
+        /// Conditional Formatting for this range.
+        /// </summary>
+        public IRangeConditionalFormatting ConditionalFormatting
+        {
+            get
+            {
+                return new RangeConditionalFormatting(_worksheet, new ExcelAddress(Address));
+            }
+        }
+        #endregion
+        #region DataValidation
+        /// <summary>
+        /// Data validation for this range.
+        /// </summary>
+        public IRangeDataValidation DataValidation
+        {
+            get
+            {
                 return new RangeDataValidation(_worksheet, Address);
-			}
-		}
-		#endregion
+            }
+        }
+        #endregion
         #region LoadFromDataReader
-	    /// <summary>
-	    /// Load the data from the datareader starting from the top left cell of the range
-	    /// </summary>
-	    /// <param name="Reader">The datareader to loadfrom</param>
-	    /// <param name="PrintHeaders">Print the column caption property (if set) or the columnname property if not, on first row</param>
-	    /// <param name="TableName">The name of the table</param>
-	    /// <param name="TableStyle">The table style to apply to the data</param>
-	    /// <returns>The filled range</returns>
-	    public ExcelRangeBase LoadFromDataReader(IDataReader Reader, bool PrintHeaders, string TableName, TableStyles TableStyle = TableStyles.None)
-	    {
-	        var r = LoadFromDataReader(Reader, PrintHeaders);
+        /// <summary>
+        /// Load the data from the datareader starting from the top left cell of the range
+        /// </summary>
+        /// <param name="Reader">The datareader to loadfrom</param>
+        /// <param name="PrintHeaders">Print the column caption property (if set) or the columnname property if not, on first row</param>
+        /// <param name="TableName">The name of the table</param>
+        /// <param name="TableStyle">The table style to apply to the data</param>
+        /// <returns>The filled range</returns>
+        public ExcelRangeBase LoadFromDataReader(IDataReader Reader, bool PrintHeaders, string TableName, TableStyles TableStyle = TableStyles.None)
+        {
+            var r = LoadFromDataReader(Reader, PrintHeaders);
 
             int rows = r.Rows - 1;
-	        if (rows >= 0 && r.Columns > 0)
-	        {
-	            var tbl = _worksheet.Tables.Add(new ExcelAddressBase(_fromRow, _fromCol, _fromRow + (rows <= 0 ? 1 : rows), _fromCol + r.Columns - 1), TableName);
-	            tbl.ShowHeader = PrintHeaders;
-	            tbl.TableStyle = TableStyle;
-	        }
-	        return r;
-	    }
+            if (rows >= 0 && r.Columns > 0)
+            {
+                var tbl = _worksheet.Tables.Add(new ExcelAddressBase(_fromRow, _fromCol, _fromRow + (rows <= 0 ? 1 : rows), _fromCol + r.Columns - 1), TableName);
+                tbl.ShowHeader = PrintHeaders;
+                tbl.TableStyle = TableStyle;
+            }
+            return r;
+        }
 
-	    /// <summary>
-	    /// Load the data from the datareader starting from the top left cell of the range
-	    /// </summary>
-	    /// <param name="Reader">The datareader to load from</param>
-	    /// <param name="PrintHeaders">Print the caption property (if set) or the columnname property if not, on first row</param>
-	    /// <returns>The filled range</returns>
-	    public ExcelRangeBase LoadFromDataReader(IDataReader Reader, bool PrintHeaders)
-	    {
-	        if (Reader == null)
-	        {
-	            throw (new ArgumentNullException("Reader", "Reader can't be null"));
-	        }
-	        int fieldCount = Reader.FieldCount;
-	  
-	        int col = _fromCol, row = _fromRow;
-	        if (PrintHeaders)
-	        {
-	            for (int i = 0; i < fieldCount; i++)
-	            {
-	                // If no caption is set, the ColumnName property is called implicitly.
-	                _worksheet.SetValueInner(row, col++, Reader.GetName(i));
-	            }
-	            row++;
-	            col = _fromCol;
-	        }
-	        while(Reader.Read())
-	        {
-	            for (int i = 0; i < fieldCount; i++)
-	            {
-	                _worksheet.SetValueInner(row, col++, Reader.GetValue(i));
-	            }
-	            row++;
-	            col = _fromCol;
-	        }
-	        return _worksheet.Cells[_fromRow, _fromCol, row - 1, _fromCol + fieldCount - 1];
-	    }
+        /// <summary>
+        /// Load the data from the datareader starting from the top left cell of the range
+        /// </summary>
+        /// <param name="Reader">The datareader to load from</param>
+        /// <param name="PrintHeaders">Print the caption property (if set) or the columnname property if not, on first row</param>
+        /// <returns>The filled range</returns>
+        public ExcelRangeBase LoadFromDataReader(IDataReader Reader, bool PrintHeaders)
+        {
+            if (Reader == null)
+            {
+                throw (new ArgumentNullException("Reader", "Reader can't be null"));
+            }
+            int fieldCount = Reader.FieldCount;
+      
+            int col = _fromCol, row = _fromRow;
+            if (PrintHeaders)
+            {
+                for (int i = 0; i < fieldCount; i++)
+                {
+                    // If no caption is set, the ColumnName property is called implicitly.
+                    _worksheet.SetValueInner(row, col++, Reader.GetName(i));
+                }
+                row++;
+                col = _fromCol;
+            }
+            while(Reader.Read())
+            {
+                for (int i = 0; i < fieldCount; i++)
+                {
+                    _worksheet.SetValueInner(row, col++, Reader.GetValue(i));
+                }
+                row++;
+                col = _fromCol;
+            }
+            return _worksheet.Cells[_fromRow, _fromCol, row - 1, _fromCol + fieldCount - 1];
+        }
         #endregion
 
 #region LoadFromDataTable
@@ -1875,26 +1875,26 @@ namespace OfficeOpenXml
         /// <param name="TableStyle">The table style to apply to the data</param>
         /// <returns>The filled range</returns>
         public ExcelRangeBase LoadFromDataTable(DataTable Table, bool PrintHeaders, TableStyles TableStyle)
-		{
-			var r = LoadFromDataTable(Table, PrintHeaders);
+        {
+            var r = LoadFromDataTable(Table, PrintHeaders);
 
             int rows = (Table.Rows.Count == 0 ? 1 : Table.Rows.Count) + (PrintHeaders ? 1 : 0);
             if (rows >= 0 && Table.Columns.Count>0)
-			{
+            {
                 var tbl = _worksheet.Tables.Add(new ExcelAddressBase(_fromRow, _fromCol, _fromRow + rows - 1, _fromCol + Table.Columns.Count-1), Table.TableName);
-				tbl.ShowHeader = PrintHeaders;
-				tbl.TableStyle = TableStyle;
-			}
-		    return r;
-		}
-		/// <summary>
-		/// Load the data from the datatable starting from the top left cell of the range
-		/// </summary>
-		/// <param name="Table">The datatable to load</param>
-		/// <param name="PrintHeaders">Print the caption property (if set) or the columnname property if not, on first row</param>
-		/// <returns>The filled range</returns>
-		public ExcelRangeBase LoadFromDataTable(DataTable Table, bool PrintHeaders)
-		{
+                tbl.ShowHeader = PrintHeaders;
+                tbl.TableStyle = TableStyle;
+            }
+            return r;
+        }
+        /// <summary>
+        /// Load the data from the datatable starting from the top left cell of the range
+        /// </summary>
+        /// <param name="Table">The datatable to load</param>
+        /// <param name="PrintHeaders">Print the caption property (if set) or the columnname property if not, on first row</param>
+        /// <returns>The filled range</returns>
+        public ExcelRangeBase LoadFromDataTable(DataTable Table, bool PrintHeaders)
+        {
             if (Table == null)
             {
                 throw (new ArgumentNullException("Table can't be null"));
@@ -1932,13 +1932,13 @@ namespace OfficeOpenXml
 #endregion
 
 #region LoadFromArrays
-		/// <summary>
-		/// Loads data from the collection of arrays of objects into the range, starting from
-		/// the top-left cell.
-		/// </summary>
-		/// <param name="Data">The data.</param>
-		public ExcelRangeBase LoadFromArrays(IEnumerable<object[]> Data)
-		{
+        /// <summary>
+        /// Loads data from the collection of arrays of objects into the range, starting from
+        /// the top-left cell.
+        /// </summary>
+        /// <param name="Data">The data.</param>
+        public ExcelRangeBase LoadFromArrays(IEnumerable<object[]> Data)
+        {
             //thanx to Abdullin for the code contribution
             if (Data == null) throw new ArgumentNullException("data");
 
@@ -1972,67 +1972,67 @@ namespace OfficeOpenXml
         }
 #endregion
 #region LoadFromCollection
-		/// <summary>
-		/// Load a collection into a the worksheet starting from the top left row of the range.
-		/// </summary>
-		/// <typeparam name="T">The datatype in the collection</typeparam>
-		/// <param name="Collection">The collection to load</param>
-		/// <returns>The filled range</returns>
-		public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection)
-		{
-			return LoadFromCollection<T>(Collection, false, TableStyles.None, BindingFlags.Public | BindingFlags.Instance, null);
-		}
-		/// <summary>
-		/// Load a collection of T into the worksheet starting from the top left row of the range.
-		/// Default option will load all public instance properties of T
-		/// </summary>
-		/// <typeparam name="T">The datatype in the collection</typeparam>
-		/// <param name="Collection">The collection to load</param>
+        /// <summary>
+        /// Load a collection into a the worksheet starting from the top left row of the range.
+        /// </summary>
+        /// <typeparam name="T">The datatype in the collection</typeparam>
+        /// <param name="Collection">The collection to load</param>
+        /// <returns>The filled range</returns>
+        public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection)
+        {
+            return LoadFromCollection<T>(Collection, false, TableStyles.None, BindingFlags.Public | BindingFlags.Instance, null);
+        }
+        /// <summary>
+        /// Load a collection of T into the worksheet starting from the top left row of the range.
+        /// Default option will load all public instance properties of T
+        /// </summary>
+        /// <typeparam name="T">The datatype in the collection</typeparam>
+        /// <param name="Collection">The collection to load</param>
         /// <param name="PrintHeaders">Print the property names on the first row. If the property is decorated with a <see cref="DisplayNameAttribute"/> or a <see cref="DescriptionAttribute"/> that attribute will be used instead of the reflected member name.</param>
-		/// <returns>The filled range</returns>
-		public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders)
-		{
-			return LoadFromCollection<T>(Collection, PrintHeaders, TableStyles.None, BindingFlags.Public | BindingFlags.Instance, null);
-		}
-		/// <summary>
-		/// Load a collection of T into the worksheet starting from the top left row of the range.
-		/// Default option will load all public instance properties of T
-		/// </summary>
-		/// <typeparam name="T">The datatype in the collection</typeparam>
-		/// <param name="Collection">The collection to load</param>
+        /// <returns>The filled range</returns>
+        public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders)
+        {
+            return LoadFromCollection<T>(Collection, PrintHeaders, TableStyles.None, BindingFlags.Public | BindingFlags.Instance, null);
+        }
+        /// <summary>
+        /// Load a collection of T into the worksheet starting from the top left row of the range.
+        /// Default option will load all public instance properties of T
+        /// </summary>
+        /// <typeparam name="T">The datatype in the collection</typeparam>
+        /// <param name="Collection">The collection to load</param>
         /// <param name="PrintHeaders">Print the property names on the first row. If the property is decorated with a <see cref="DisplayNameAttribute"/> or a <see cref="DescriptionAttribute"/> that attribute will be used instead of the reflected member name.</param>
-		/// <param name="TableStyle">Will create a table with this style. If set to TableStyles.None no table will be created</param>
-		/// <returns>The filled range</returns>
-		public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders, TableStyles TableStyle)
-		{
-			return LoadFromCollection<T>(Collection, PrintHeaders, TableStyle, BindingFlags.Public | BindingFlags.Instance, null);
-		}
-		/// <summary>
-		/// Load a collection into the worksheet starting from the top left row of the range.
-		/// </summary>
-		/// <typeparam name="T">The datatype in the collection</typeparam>
-		/// <param name="Collection">The collection to load</param>
-		/// <param name="PrintHeaders">Print the property names on the first row. Any underscore in the property name will be converted to a space. If the property is decorated with a <see cref="DisplayNameAttribute"/> or a <see cref="DescriptionAttribute"/> that attribute will be used instead of the reflected member name.</param>
-		/// <param name="TableStyle">Will create a table with this style. If set to TableStyles.None no table will be created</param>
-		/// <param name="memberFlags">Property flags to use</param>
-		/// <param name="Members">The properties to output. Must be of type T</param>
-		/// <returns>The filled range</returns>
-		public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders, TableStyles TableStyle, BindingFlags memberFlags, MemberInfo[] Members)
-		{
-			var type = typeof(T);
+        /// <param name="TableStyle">Will create a table with this style. If set to TableStyles.None no table will be created</param>
+        /// <returns>The filled range</returns>
+        public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders, TableStyles TableStyle)
+        {
+            return LoadFromCollection<T>(Collection, PrintHeaders, TableStyle, BindingFlags.Public | BindingFlags.Instance, null);
+        }
+        /// <summary>
+        /// Load a collection into the worksheet starting from the top left row of the range.
+        /// </summary>
+        /// <typeparam name="T">The datatype in the collection</typeparam>
+        /// <param name="Collection">The collection to load</param>
+        /// <param name="PrintHeaders">Print the property names on the first row. Any underscore in the property name will be converted to a space. If the property is decorated with a <see cref="DisplayNameAttribute"/> or a <see cref="DescriptionAttribute"/> that attribute will be used instead of the reflected member name.</param>
+        /// <param name="TableStyle">Will create a table with this style. If set to TableStyles.None no table will be created</param>
+        /// <param name="memberFlags">Property flags to use</param>
+        /// <param name="Members">The properties to output. Must be of type T</param>
+        /// <returns>The filled range</returns>
+        public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders, TableStyles TableStyle, BindingFlags memberFlags, MemberInfo[] Members)
+        {
+            var type = typeof(T);
             bool isSameType=true;
-			if (Members == null)
-			{
-				Members = type.GetProperties(memberFlags);
+            if (Members == null)
+            {
+                Members = type.GetProperties(memberFlags);
             }
-			else
-			{
+            else
+            {
                 if(Members.Length==0)   //Fixes issue 15555
                 {
                     throw (new ArgumentException("Parameter Members must have at least one property. Length is zero"));
                 }
                 foreach (var t in Members)
-				{
+                {
                     if (t.DeclaringType!=null && t.DeclaringType != type)
                     {
                         isSameType = false;
@@ -2042,8 +2042,8 @@ namespace OfficeOpenXml
                     {
                         throw new InvalidCastException("Supplied properties in parameter Properties must be of the same type as T (or an assignable type from T)");
                     }
-				}
-			}
+                }
+            }
 
             // create buffer
             object[,] values = new object[(PrintHeaders ? Collection.Count() + 1 : Collection.Count()), Members.Count()];
@@ -2076,16 +2076,16 @@ namespace OfficeOpenXml
                     //_worksheet.SetValueInner(row, col++, header);
                     values[row, col++] = header;
                 }
-				row++;
-			}
+                row++;
+            }
 
-		    if (!Collection.Any() && (Members.Length == 0 || PrintHeaders == false))
-		    {
-		        return null;
-		    }
+            if (!Collection.Any() && (Members.Length == 0 || PrintHeaders == false))
+            {
+                return null;
+            }
 
-			foreach (var item in Collection)
-			{
+            foreach (var item in Collection)
+            {
                 col = 0;
                 if (item is string || item is decimal || item is DateTime || TypeCompat.IsPrimitive(item))
                 {
@@ -2114,8 +2114,8 @@ namespace OfficeOpenXml
                         }
                     }
                 }
-				row++;
-			}
+                row++;
+            }
 
             _worksheet.SetRangeValueInner(_fromRow, _fromCol, _fromRow + row - 1, _fromCol + col - 1, values);
 
@@ -2127,26 +2127,26 @@ namespace OfficeOpenXml
 
             var r = _worksheet.Cells[_fromRow, _fromCol, _fromRow + row - 1, _fromCol + col - 1];
 
-			if (TableStyle != TableStyles.None)
-			{
-				var tbl = _worksheet.Tables.Add(r, "");
-				tbl.ShowHeader = PrintHeaders;
-				tbl.TableStyle = TableStyle;
-			}
-			return r;
-		}
+            if (TableStyle != TableStyles.None)
+            {
+                var tbl = _worksheet.Tables.Add(r, "");
+                tbl.ShowHeader = PrintHeaders;
+                tbl.TableStyle = TableStyle;
+            }
+            return r;
+        }
 #endregion
 #region LoadFromText
-		/// <summary>
-		/// Loads a CSV text into a range starting from the top left cell.
-		/// Default settings is Comma separation
-		/// </summary>
-		/// <param name="Text">The Text</param>
-		/// <returns>The range containing the data</returns>
-		public ExcelRangeBase LoadFromText(string Text)
-		{
-			return LoadFromText(Text, new ExcelTextFormat());
-		}
+        /// <summary>
+        /// Loads a CSV text into a range starting from the top left cell.
+        /// Default settings is Comma separation
+        /// </summary>
+        /// <param name="Text">The Text</param>
+        /// <returns>The range containing the data</returns>
+        public ExcelRangeBase LoadFromText(string Text)
+        {
+            return LoadFromText(Text, new ExcelTextFormat());
+        }
         /// <summary>
         /// Loads a CSV text into a range starting from the top left cell.
         /// </summary>
@@ -2331,46 +2331,46 @@ namespace OfficeOpenXml
         /// <param name="FirstRowIsHeader">Use the first row as header</param>
         /// <returns></returns>
         public ExcelRangeBase LoadFromText(string Text, ExcelTextFormat Format, TableStyles TableStyle, bool FirstRowIsHeader)
-		{
-			var r = LoadFromText(Text, Format);
+        {
+            var r = LoadFromText(Text, Format);
 
-			var tbl = _worksheet.Tables.Add(r, "");
-			tbl.ShowHeader = FirstRowIsHeader;
-			tbl.TableStyle = TableStyle;
+            var tbl = _worksheet.Tables.Add(r, "");
+            tbl.ShowHeader = FirstRowIsHeader;
+            tbl.TableStyle = TableStyle;
 
-			return r;
-		}
+            return r;
+        }
         /// <summary>
         /// Loads a CSV file into a range starting from the top left cell.
         /// </summary>
         /// <param name="TextFile">The Textfile</param>
         /// <returns></returns>
         public ExcelRangeBase LoadFromText(FileInfo TextFile)
-		{
-			return LoadFromText(File.ReadAllText(TextFile.FullName, Encoding.ASCII));
-		}
-		/// <summary>
-		/// Loads a CSV file into a range starting from the top left cell.
-		/// </summary>
-		/// <param name="TextFile">The Textfile</param>
-		/// <param name="Format">Information how to load the text</param>
-		/// <returns></returns>
-		public ExcelRangeBase LoadFromText(FileInfo TextFile, ExcelTextFormat Format)
-		{
-			return LoadFromText(File.ReadAllText(TextFile.FullName, Format.Encoding), Format);
-		}
-		/// <summary>
-		/// Loads a CSV file into a range starting from the top left cell.
-		/// </summary>
-		/// <param name="TextFile">The Textfile</param>
-		/// <param name="Format">Information how to load the text</param>
-		/// <param name="TableStyle">Create a table with this style</param>
-		/// <param name="FirstRowIsHeader">Use the first row as header</param>
-		/// <returns></returns>
-		public ExcelRangeBase LoadFromText(FileInfo TextFile, ExcelTextFormat Format, TableStyles TableStyle, bool FirstRowIsHeader)
-		{
-			return LoadFromText(File.ReadAllText(TextFile.FullName, Format.Encoding), Format, TableStyle, FirstRowIsHeader);
-		}
+        {
+            return LoadFromText(File.ReadAllText(TextFile.FullName, Encoding.ASCII));
+        }
+        /// <summary>
+        /// Loads a CSV file into a range starting from the top left cell.
+        /// </summary>
+        /// <param name="TextFile">The Textfile</param>
+        /// <param name="Format">Information how to load the text</param>
+        /// <returns></returns>
+        public ExcelRangeBase LoadFromText(FileInfo TextFile, ExcelTextFormat Format)
+        {
+            return LoadFromText(File.ReadAllText(TextFile.FullName, Format.Encoding), Format);
+        }
+        /// <summary>
+        /// Loads a CSV file into a range starting from the top left cell.
+        /// </summary>
+        /// <param name="TextFile">The Textfile</param>
+        /// <param name="Format">Information how to load the text</param>
+        /// <param name="TableStyle">Create a table with this style</param>
+        /// <param name="FirstRowIsHeader">Use the first row as header</param>
+        /// <returns></returns>
+        public ExcelRangeBase LoadFromText(FileInfo TextFile, ExcelTextFormat Format, TableStyles TableStyle, bool FirstRowIsHeader)
+        {
+            return LoadFromText(File.ReadAllText(TextFile.FullName, Format.Encoding), Format, TableStyle, FirstRowIsHeader);
+        }
 #endregion
 #region GetValue
 
@@ -2398,61 +2398,61 @@ namespace OfficeOpenXml
         ///      <see cref="Value"/> is not string and direct conversion fails
         /// </exception>
         public T GetValue<T>()
-		{
+        {
             return ConvertUtil.GetTypedCellValue<T>(Value);
-		}
+        }
 #endregion
-		/// <summary>
-		/// Get a range with an offset from the top left cell.
-		/// The new range has the same dimensions as the current range
-		/// </summary>
-		/// <param name="RowOffset">Row Offset</param>
-		/// <param name="ColumnOffset">Column Offset</param>
-		/// <returns></returns>
-		public ExcelRangeBase Offset(int RowOffset, int ColumnOffset)
-		{
-			if (_fromRow + RowOffset < 1 || _fromCol + ColumnOffset < 1 || _fromRow + RowOffset > ExcelPackage.MaxRows || _fromCol + ColumnOffset > ExcelPackage.MaxColumns)
-			{
-				throw (new ArgumentOutOfRangeException("Offset value out of range"));
-			}
-			string address = GetAddress(_fromRow + RowOffset, _fromCol + ColumnOffset, _toRow + RowOffset, _toCol + ColumnOffset);
-			return new ExcelRangeBase(_worksheet, address);
-		}
-		/// <summary>
-		/// Get a range with an offset from the top left cell.
-		/// </summary>
-		/// <param name="RowOffset">Row Offset</param>
-		/// <param name="ColumnOffset">Column Offset</param>
-		/// <param name="NumberOfRows">Number of rows. Minimum 1</param>
-		/// <param name="NumberOfColumns">Number of colums. Minimum 1</param>
-		/// <returns></returns>
-		public ExcelRangeBase Offset(int RowOffset, int ColumnOffset, int NumberOfRows, int NumberOfColumns)
-		{
-			if (NumberOfRows < 1 || NumberOfColumns < 1)
-			{
-				throw (new Exception("Number of rows/columns must be greater than 0"));
-			}
-			NumberOfRows--;
-			NumberOfColumns--;
-			if (_fromRow + RowOffset < 1 || _fromCol + ColumnOffset < 1 || _fromRow + RowOffset > ExcelPackage.MaxRows || _fromCol + ColumnOffset > ExcelPackage.MaxColumns ||
-				 _fromRow + RowOffset + NumberOfRows < 1 || _fromCol + ColumnOffset + NumberOfColumns < 1 || _fromRow + RowOffset + NumberOfRows > ExcelPackage.MaxRows || _fromCol + ColumnOffset + NumberOfColumns > ExcelPackage.MaxColumns)
-			{
-				throw (new ArgumentOutOfRangeException("Offset value out of range"));
-			}
-			string address = GetAddress(_fromRow + RowOffset, _fromCol + ColumnOffset, _fromRow + RowOffset + NumberOfRows, _fromCol + ColumnOffset + NumberOfColumns);
-			return new ExcelRangeBase(_worksheet, address);
-		}
-		/// <summary>
-		/// Adds a new comment for the range.
-		/// If this range contains more than one cell, the top left comment is returned by the method.
-		/// </summary>
-		/// <param name="Text"></param>
-		/// <param name="Author"></param>
-		/// <returns>A reference comment of the top left cell</returns>
-		public ExcelComment AddComment(string Text, string Author)
-		{
-		    if (string.IsNullOrEmpty(Author))
-		    {
+        /// <summary>
+        /// Get a range with an offset from the top left cell.
+        /// The new range has the same dimensions as the current range
+        /// </summary>
+        /// <param name="RowOffset">Row Offset</param>
+        /// <param name="ColumnOffset">Column Offset</param>
+        /// <returns></returns>
+        public ExcelRangeBase Offset(int RowOffset, int ColumnOffset)
+        {
+            if (_fromRow + RowOffset < 1 || _fromCol + ColumnOffset < 1 || _fromRow + RowOffset > ExcelPackage.MaxRows || _fromCol + ColumnOffset > ExcelPackage.MaxColumns)
+            {
+                throw (new ArgumentOutOfRangeException("Offset value out of range"));
+            }
+            string address = GetAddress(_fromRow + RowOffset, _fromCol + ColumnOffset, _toRow + RowOffset, _toCol + ColumnOffset);
+            return new ExcelRangeBase(_worksheet, address);
+        }
+        /// <summary>
+        /// Get a range with an offset from the top left cell.
+        /// </summary>
+        /// <param name="RowOffset">Row Offset</param>
+        /// <param name="ColumnOffset">Column Offset</param>
+        /// <param name="NumberOfRows">Number of rows. Minimum 1</param>
+        /// <param name="NumberOfColumns">Number of colums. Minimum 1</param>
+        /// <returns></returns>
+        public ExcelRangeBase Offset(int RowOffset, int ColumnOffset, int NumberOfRows, int NumberOfColumns)
+        {
+            if (NumberOfRows < 1 || NumberOfColumns < 1)
+            {
+                throw (new Exception("Number of rows/columns must be greater than 0"));
+            }
+            NumberOfRows--;
+            NumberOfColumns--;
+            if (_fromRow + RowOffset < 1 || _fromCol + ColumnOffset < 1 || _fromRow + RowOffset > ExcelPackage.MaxRows || _fromCol + ColumnOffset > ExcelPackage.MaxColumns ||
+                 _fromRow + RowOffset + NumberOfRows < 1 || _fromCol + ColumnOffset + NumberOfColumns < 1 || _fromRow + RowOffset + NumberOfRows > ExcelPackage.MaxRows || _fromCol + ColumnOffset + NumberOfColumns > ExcelPackage.MaxColumns)
+            {
+                throw (new ArgumentOutOfRangeException("Offset value out of range"));
+            }
+            string address = GetAddress(_fromRow + RowOffset, _fromCol + ColumnOffset, _fromRow + RowOffset + NumberOfRows, _fromCol + ColumnOffset + NumberOfColumns);
+            return new ExcelRangeBase(_worksheet, address);
+        }
+        /// <summary>
+        /// Adds a new comment for the range.
+        /// If this range contains more than one cell, the top left comment is returned by the method.
+        /// </summary>
+        /// <param name="Text"></param>
+        /// <param name="Author"></param>
+        /// <returns>A reference comment of the top left cell</returns>
+        public ExcelComment AddComment(string Text, string Author)
+        {
+            if (string.IsNullOrEmpty(Author))
+            {
 #if Core
                 Author = System.Security.Claims.ClaimsPrincipal.Current.Identity.Name;
 #else
@@ -2460,12 +2460,12 @@ namespace OfficeOpenXml
 #endif
             }
             //Check if any comments exists in the range and throw an exception
-			_changePropMethod(this, _setExistsCommentDelegate, null);
-			//Create the comments
-			_changePropMethod(this, _setCommentDelegate, new string[] { Text, Author });
+            _changePropMethod(this, _setExistsCommentDelegate, null);
+            //Create the comments
+            _changePropMethod(this, _setCommentDelegate, new string[] { Text, Author });
 
-			return _worksheet.Comments[new ExcelCellAddress(_fromRow, _fromCol)];
-		}
+            return _worksheet.Comments[new ExcelCellAddress(_fromRow, _fromCol)];
+        }
 
         /// <summary>
         /// Copies the range of cells to an other range
@@ -2706,30 +2706,30 @@ namespace OfficeOpenXml
         /// Clear all cells
         /// </summary>
         public void Clear()
-		{
-			Delete(this, false);
-		}
-		/// <summary>
-		/// Creates an array-formula.
-		/// </summary>
-		/// <param name="ArrayFormula">The formula</param>
-		public void CreateArrayFormula(string ArrayFormula)
-		{
-			if (Addresses != null)
-			{
-				throw (new Exception("An Arrayformula can not have more than one address"));
-			}
-			Set_SharedFormula(this, ArrayFormula, this, true);
-		}
+        {
+            Delete(this, false);
+        }
+        /// <summary>
+        /// Creates an array-formula.
+        /// </summary>
+        /// <param name="ArrayFormula">The formula</param>
+        public void CreateArrayFormula(string ArrayFormula)
+        {
+            if (Addresses != null)
+            {
+                throw (new Exception("An Arrayformula can not have more than one address"));
+            }
+            Set_SharedFormula(this, ArrayFormula, this, true);
+        }
         //private void Clear(ExcelAddressBase Range)
         //{
         //    Clear(Range, true);
         //}
         internal void Delete(ExcelAddressBase Range, bool shift)
-		{
+        {
             //DeleteCheckMergedCells(Range);
             _worksheet.MergedCells.Clear(Range);
-			//First find the start cell
+            //First find the start cell
             int fromRow, fromCol;
             var d = Worksheet.Dimension;
             if (d != null && Range._fromRow <= d._fromRow && Range._toRow >= d._toRow) //EntireRow?
@@ -2760,13 +2760,13 @@ namespace OfficeOpenXml
             _worksheet._flags.Delete(fromRow, fromCol, rows, cols, shift);
             _worksheet._commentsStore.Delete(fromRow, fromCol, rows, cols, shift);
 
-			//Clear multi addresses as well
-			if (Addresses != null)
-			{
-				foreach (var sub in Addresses)
-				{
-					Delete(sub, shift);
-				}
+            //Clear multi addresses as well
+            if (Addresses != null)
+            {
+                foreach (var sub in Addresses)
+                {
+                    Delete(sub, shift);
+                }
             }
         }
 
@@ -2791,58 +2791,58 @@ namespace OfficeOpenXml
             foreach (var item in removeItems)
             {
                 Worksheet.MergedCells.Remove(item);
-			}
-		}
+            }
+        }
 #endregion
 #region IDisposable Members
 
-		public void Dispose()
-		{
-			//_worksheet = null;            
-		}
+        public void Dispose()
+        {
+            //_worksheet = null;            
+        }
 
 #endregion
 #region "Enumerator"
         CellsStoreEnumerator<ExcelCoreValue> cellEnum;
-		public IEnumerator<ExcelRangeBase> GetEnumerator()
-		{
-			Reset();
-			return this;
-		}
+        public IEnumerator<ExcelRangeBase> GetEnumerator()
+        {
+            Reset();
+            return this;
+        }
 
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			Reset();
-			return this;
-		}
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            Reset();
+            return this;
+        }
 
-		/// <summary>
-		/// The current range when enumerating
-		/// </summary>
-		public ExcelRangeBase Current
-		{
-			get
-			{
-				return new ExcelRangeBase(_worksheet, ExcelAddressBase.GetAddress(cellEnum.Row, cellEnum.Column));
-			}
-		}
+        /// <summary>
+        /// The current range when enumerating
+        /// </summary>
+        public ExcelRangeBase Current
+        {
+            get
+            {
+                return new ExcelRangeBase(_worksheet, ExcelAddressBase.GetAddress(cellEnum.Row, cellEnum.Column));
+            }
+        }
 
-		/// <summary>
-		/// The current range when enumerating
-		/// </summary>
-		object IEnumerator.Current
-		{
-			get
-			{
-				return ((object)(new ExcelRangeBase(_worksheet, ExcelAddressBase.GetAddress(cellEnum.Row, cellEnum.Column))));
-			}
-		}
+        /// <summary>
+        /// The current range when enumerating
+        /// </summary>
+        object IEnumerator.Current
+        {
+            get
+            {
+                return ((object)(new ExcelRangeBase(_worksheet, ExcelAddressBase.GetAddress(cellEnum.Row, cellEnum.Column))));
+            }
+        }
 
         //public object FormatedText { get; private set; }
 
         int _enumAddressIx = -1;
         public bool MoveNext()
-		{
+        {
             if (cellEnum.Next())
             {
                 return true;
@@ -2865,10 +2865,10 @@ namespace OfficeOpenXml
                 }
             }
             return false;
-		}
+        }
 
-		public void Reset()
-		{
+        public void Reset()
+        {
             _enumAddressIx = -1;
             cellEnum = new CellsStoreEnumerator<ExcelCoreValue>(_worksheet._values, _fromRow, _fromCol, _toRow, _toCol);
         }

--- a/EPPlus/ExcelRow.cs
+++ b/EPPlus/ExcelRow.cs
@@ -35,7 +35,7 @@ using System.Xml;
 using OfficeOpenXml.Style;
 namespace OfficeOpenXml
 {
-	internal class RowInternal
+    internal class RowInternal
     {
         internal double Height=-1;
         internal bool Hidden;
@@ -61,12 +61,12 @@ namespace OfficeOpenXml
         }
     }
     /// <summary>
-	/// Represents an individual row in the spreadsheet.
-	/// </summary>
-	public class ExcelRow : IRangeID
-	{
-		private ExcelWorksheet _worksheet;
-		private XmlElement _rowElement = null;
+    /// Represents an individual row in the spreadsheet.
+    /// </summary>
+    public class ExcelRow : IRangeID
+    {
+        private ExcelWorksheet _worksheet;
+        private XmlElement _rowElement = null;
         /// <summary>
         /// Internal RowID.
         /// </summary>
@@ -78,30 +78,30 @@ namespace OfficeOpenXml
                 return GetRowID(_worksheet.SheetID, Row);
             }
         }
-		#region ExcelRow Constructor
-		/// <summary>
-		/// Creates a new instance of the ExcelRow class. 
-		/// For internal use only!
-		/// </summary>
-		/// <param name="Worksheet">The parent worksheet</param>
-		/// <param name="row">The row number</param>
-		internal ExcelRow(ExcelWorksheet Worksheet, int row)
-		{
-			_worksheet = Worksheet;
-            Row = row;
-		}
-		#endregion
-
-		/// <summary>
-		/// Provides access to the node representing the row.
-		/// </summary>
-		internal XmlNode Node { get { return (_rowElement); } }
-
-		#region ExcelRow Hidden
+        #region ExcelRow Constructor
         /// <summary>
-		/// Allows the row to be hidden in the worksheet
-		/// </summary>
-		public bool Hidden
+        /// Creates a new instance of the ExcelRow class. 
+        /// For internal use only!
+        /// </summary>
+        /// <param name="Worksheet">The parent worksheet</param>
+        /// <param name="row">The row number</param>
+        internal ExcelRow(ExcelWorksheet Worksheet, int row)
+        {
+            _worksheet = Worksheet;
+            Row = row;
+        }
+        #endregion
+
+        /// <summary>
+        /// Provides access to the node representing the row.
+        /// </summary>
+        internal XmlNode Node { get { return (_rowElement); } }
+
+        #region ExcelRow Hidden
+        /// <summary>
+        /// Allows the row to be hidden in the worksheet
+        /// </summary>
+        public bool Hidden
         {
             get
             {
@@ -121,16 +121,16 @@ namespace OfficeOpenXml
                 r.Hidden=value;
             }
         }        
-		#endregion
+        #endregion
 
-		#region ExcelRow Height
+        #region ExcelRow Height
         /// <summary>
-		/// Sets the height of the row
-		/// </summary>
-		public double Height
+        /// Sets the height of the row
+        /// </summary>
+        public double Height
         {
-			get
-			{
+            get
+            {
                 var r = (RowInternal)_worksheet.GetValueInner(Row, 0);
                 if (r == null || r.Height<0)
                 {
@@ -185,7 +185,7 @@ namespace OfficeOpenXml
                 r.CustomHeight = value;
             }
         }
-		#endregion
+        #endregion
 
         internal string _styleName = "";
         /// <summary>

--- a/EPPlus/ExcelStyles.cs
+++ b/EPPlus/ExcelStyles.cs
@@ -41,9 +41,9 @@ using OfficeOpenXml.Style.Dxf;
 using OfficeOpenXml.ConditionalFormatting;
 namespace OfficeOpenXml
 {
-	/// <summary>
-	/// Containts all shared cell styles for a workbook
-	/// </summary>
+    /// <summary>
+    /// Containts all shared cell styles for a workbook
+    /// </summary>
     public sealed class ExcelStyles : XmlHelper
     {
         const string NumberFormatsPath = "d:styleSheet/d:numFmts";

--- a/EPPlus/ExcelWorkbook.cs
+++ b/EPPlus/ExcelWorkbook.cs
@@ -53,107 +53,107 @@ using OfficeOpenXml.Compatibility;
 
 namespace OfficeOpenXml
 {
-	#region Public Enum ExcelCalcMode
-	/// <summary>
-	/// How the application should calculate formulas in the workbook
-	/// </summary>
-	public enum ExcelCalcMode
-	{
-		/// <summary>
-		/// Indicates that calculations in the workbook are performed automatically when cell values change. 
-		/// The application recalculates those cells that are dependent on other cells that contain changed values. 
-		/// This mode of calculation helps to avoid unnecessary calculations.
-		/// </summary>
-		Automatic,
-		/// <summary>
-		/// Indicates tables be excluded during automatic calculation
-		/// </summary>
-		AutomaticNoTable,
-		/// <summary>
-		/// Indicates that calculations in the workbook be triggered manually by the user. 
-		/// </summary>
-		Manual
-	}
-	#endregion
+    #region Public Enum ExcelCalcMode
+    /// <summary>
+    /// How the application should calculate formulas in the workbook
+    /// </summary>
+    public enum ExcelCalcMode
+    {
+        /// <summary>
+        /// Indicates that calculations in the workbook are performed automatically when cell values change. 
+        /// The application recalculates those cells that are dependent on other cells that contain changed values. 
+        /// This mode of calculation helps to avoid unnecessary calculations.
+        /// </summary>
+        Automatic,
+        /// <summary>
+        /// Indicates tables be excluded during automatic calculation
+        /// </summary>
+        AutomaticNoTable,
+        /// <summary>
+        /// Indicates that calculations in the workbook be triggered manually by the user. 
+        /// </summary>
+        Manual
+    }
+    #endregion
 
-	/// <summary>
-	/// Represents the Excel workbook and provides access to all the 
-	/// document properties and worksheets within the workbook.
-	/// </summary>
-	public sealed class ExcelWorkbook : XmlHelper, IDisposable
-	{
-		internal class SharedStringItem
-		{
-			internal int pos;
-			internal string Text;
-			internal bool isRichText = false;
-		}
-		#region Private Properties
-		internal ExcelPackage _package;
-		internal ExcelWorksheets _worksheets;
-		private OfficeProperties _properties;
+    /// <summary>
+    /// Represents the Excel workbook and provides access to all the 
+    /// document properties and worksheets within the workbook.
+    /// </summary>
+    public sealed class ExcelWorkbook : XmlHelper, IDisposable
+    {
+        internal class SharedStringItem
+        {
+            internal int pos;
+            internal string Text;
+            internal bool isRichText = false;
+        }
+        #region Private Properties
+        internal ExcelPackage _package;
+        internal ExcelWorksheets _worksheets;
+        private OfficeProperties _properties;
 
-		private ExcelStyles _styles;
-		#endregion
+        private ExcelStyles _styles;
+        #endregion
 
-		#region ExcelWorkbook Constructor
-		/// <summary>
-		/// Creates a new instance of the ExcelWorkbook class.
-		/// </summary>
-		/// <param name="package">The parent package</param>
-		/// <param name="namespaceManager">NamespaceManager</param>
-		internal ExcelWorkbook(ExcelPackage package, XmlNamespaceManager namespaceManager) :
-			base(namespaceManager)
-		{
-			_package = package;
-			WorkbookUri = new Uri("/xl/workbook.xml", UriKind.Relative);
-			SharedStringsUri = new Uri("/xl/sharedStrings.xml", UriKind.Relative);
-			StylesUri = new Uri("/xl/styles.xml", UriKind.Relative);
+        #region ExcelWorkbook Constructor
+        /// <summary>
+        /// Creates a new instance of the ExcelWorkbook class.
+        /// </summary>
+        /// <param name="package">The parent package</param>
+        /// <param name="namespaceManager">NamespaceManager</param>
+        internal ExcelWorkbook(ExcelPackage package, XmlNamespaceManager namespaceManager) :
+            base(namespaceManager)
+        {
+            _package = package;
+            WorkbookUri = new Uri("/xl/workbook.xml", UriKind.Relative);
+            SharedStringsUri = new Uri("/xl/sharedStrings.xml", UriKind.Relative);
+            StylesUri = new Uri("/xl/styles.xml", UriKind.Relative);
 
-			_names = new ExcelNamedRangeCollection(this);
-			_namespaceManager = namespaceManager;
-			TopNode = WorkbookXml.DocumentElement;
-			SchemaNodeOrder = new string[] { "fileVersion", "fileSharing", "workbookPr", "workbookProtection", "bookViews", "sheets", "functionGroups", "functionPrototypes", "externalReferences", "definedNames", "calcPr", "oleSize", "customWorkbookViews", "pivotCaches", "smartTagPr", "smartTagTypes", "webPublishing", "fileRecoveryPr", "webPublishObjects", "extLst" };
-		    FullCalcOnLoad = true;  //Full calculation on load by default, for both new workbooks and templates.
-			GetSharedStrings();
-		}
-		#endregion
+            _names = new ExcelNamedRangeCollection(this);
+            _namespaceManager = namespaceManager;
+            TopNode = WorkbookXml.DocumentElement;
+            SchemaNodeOrder = new string[] { "fileVersion", "fileSharing", "workbookPr", "workbookProtection", "bookViews", "sheets", "functionGroups", "functionPrototypes", "externalReferences", "definedNames", "calcPr", "oleSize", "customWorkbookViews", "pivotCaches", "smartTagPr", "smartTagTypes", "webPublishing", "fileRecoveryPr", "webPublishObjects", "extLst" };
+            FullCalcOnLoad = true;  //Full calculation on load by default, for both new workbooks and templates.
+            GetSharedStrings();
+        }
+        #endregion
 
-		internal Dictionary<string, SharedStringItem> _sharedStrings = new Dictionary<string, SharedStringItem>(); //Used when reading cells.
-		internal List<SharedStringItem> _sharedStringsList = new List<SharedStringItem>(); //Used when reading cells.
-		internal ExcelNamedRangeCollection _names;
-		internal int _nextDrawingID = 0;
-		internal int _nextTableID = int.MinValue;
+        internal Dictionary<string, SharedStringItem> _sharedStrings = new Dictionary<string, SharedStringItem>(); //Used when reading cells.
+        internal List<SharedStringItem> _sharedStringsList = new List<SharedStringItem>(); //Used when reading cells.
+        internal ExcelNamedRangeCollection _names;
+        internal int _nextDrawingID = 0;
+        internal int _nextTableID = int.MinValue;
         internal int _nextPivotTableID = int.MinValue;
-		internal XmlNamespaceManager _namespaceManager;
+        internal XmlNamespaceManager _namespaceManager;
         internal FormulaParser _formulaParser = null;
-	    internal FormulaParserManager _parserManager;
+        internal FormulaParserManager _parserManager;
         internal CellStore<List<Token>> _formulaTokens;
-		/// <summary>
-		/// Read shared strings to list
-		/// </summary>
-		private void GetSharedStrings()
-		{
-			if (_package.Package.PartExists(SharedStringsUri))
-			{
-				var xml = _package.GetXmlFromUri(SharedStringsUri);
-				XmlNodeList nl = xml.SelectNodes("//d:sst/d:si", NameSpaceManager);
-				_sharedStringsList = new List<SharedStringItem>();
-				if (nl != null)
-				{
-					foreach (XmlNode node in nl)
-					{
-						XmlNode n = node.SelectSingleNode("d:t", NameSpaceManager);
-						if (n != null)
-						{
+        /// <summary>
+        /// Read shared strings to list
+        /// </summary>
+        private void GetSharedStrings()
+        {
+            if (_package.Package.PartExists(SharedStringsUri))
+            {
+                var xml = _package.GetXmlFromUri(SharedStringsUri);
+                XmlNodeList nl = xml.SelectNodes("//d:sst/d:si", NameSpaceManager);
+                _sharedStringsList = new List<SharedStringItem>();
+                if (nl != null)
+                {
+                    foreach (XmlNode node in nl)
+                    {
+                        XmlNode n = node.SelectSingleNode("d:t", NameSpaceManager);
+                        if (n != null)
+                        {
                             _sharedStringsList.Add(new SharedStringItem() { Text = ConvertUtil.ExcelDecodeString(n.InnerText) });
-						}
-						else
-						{
-							_sharedStringsList.Add(new SharedStringItem() { Text = node.InnerXml, isRichText = true });
-						}
-					}
-				}
+                        }
+                        else
+                        {
+                            _sharedStringsList.Add(new SharedStringItem() { Text = node.InnerXml, isRichText = true });
+                        }
+                    }
+                }
                 //Delete the shared string part, it will be recreated when the package is saved.
                 foreach (var rel in Part.GetRelationships())
                 {
@@ -164,76 +164,76 @@ namespace OfficeOpenXml
                     }
                 }                
                 _package.Package.DeletePart(SharedStringsUri); //Remove the part, it is recreated when saved.
-			}
-		}
-		internal void GetDefinedNames()
-		{
-			XmlNodeList nl = WorkbookXml.SelectNodes("//d:definedNames/d:definedName", NameSpaceManager);
-			if (nl != null)
-			{
-				foreach (XmlElement elem in nl)
-				{ 
-					string fullAddress = elem.InnerText;
+            }
+        }
+        internal void GetDefinedNames()
+        {
+            XmlNodeList nl = WorkbookXml.SelectNodes("//d:definedNames/d:definedName", NameSpaceManager);
+            if (nl != null)
+            {
+                foreach (XmlElement elem in nl)
+                { 
+                    string fullAddress = elem.InnerText;
 
-					int localSheetID;
-					ExcelWorksheet nameWorksheet;
-					
+                    int localSheetID;
+                    ExcelWorksheet nameWorksheet;
+                    
                     if(!int.TryParse(elem.GetAttribute("localSheetId"), NumberStyles.Number, CultureInfo.InvariantCulture, out localSheetID))
-					{
-						localSheetID = -1;
-						nameWorksheet=null;
-					}
-					else
-					{
-						nameWorksheet=Worksheets[localSheetID + _package._worksheetAdd];
-					}
+                    {
+                        localSheetID = -1;
+                        nameWorksheet=null;
+                    }
+                    else
+                    {
+                        nameWorksheet=Worksheets[localSheetID + _package._worksheetAdd];
+                    }
 
-					var addressType = ExcelAddressBase.IsValid(fullAddress);
-					ExcelRangeBase range;
-					ExcelNamedRange namedRange;
+                    var addressType = ExcelAddressBase.IsValid(fullAddress);
+                    ExcelRangeBase range;
+                    ExcelNamedRange namedRange;
 
-					if (fullAddress.IndexOf("[") == 0)
-					{
-						int start = fullAddress.IndexOf("[");
-						int end = fullAddress.IndexOf("]", start);
-						if (start >= 0 && end >= 0)
-						{
+                    if (fullAddress.IndexOf("[") == 0)
+                    {
+                        int start = fullAddress.IndexOf("[");
+                        int end = fullAddress.IndexOf("]", start);
+                        if (start >= 0 && end >= 0)
+                        {
 
-							string externalIndex = fullAddress.Substring(start + 1, end - start - 1);
-							int index;
-							if (int.TryParse(externalIndex, NumberStyles.Any, CultureInfo.InvariantCulture, out index))
-							{
-								if (index > 0 && index <= _externalReferences.Count)
-								{
-									fullAddress = fullAddress.Substring(0, start) + "[" + _externalReferences[index - 1] + "]" + fullAddress.Substring(end + 1);
-								}
-							}
-						}
-					}
+                            string externalIndex = fullAddress.Substring(start + 1, end - start - 1);
+                            int index;
+                            if (int.TryParse(externalIndex, NumberStyles.Any, CultureInfo.InvariantCulture, out index))
+                            {
+                                if (index > 0 && index <= _externalReferences.Count)
+                                {
+                                    fullAddress = fullAddress.Substring(0, start) + "[" + _externalReferences[index - 1] + "]" + fullAddress.Substring(end + 1);
+                                }
+                            }
+                        }
+                    }
 
-					if (addressType == ExcelAddressBase.AddressType.Invalid || addressType == ExcelAddressBase.AddressType.InternalName || addressType == ExcelAddressBase.AddressType.ExternalName || addressType==ExcelAddressBase.AddressType.Formula || addressType==ExcelAddressBase.AddressType.ExternalAddress)    //A value or a formula
-					{
-						double value;
-						range = new ExcelRangeBase(this, nameWorksheet, elem.GetAttribute("name"), true);
-						if (nameWorksheet == null)
-						{
-							namedRange = _names.Add(elem.GetAttribute("name"), range);
-						}
-						else
-						{
-							namedRange = nameWorksheet.Names.Add(elem.GetAttribute("name"), range);
-						}
-						
-						if (Utils.ConvertUtil._invariantCompareInfo.IsPrefix(fullAddress, "\"")) //String value
-						{
-							namedRange.NameValue = fullAddress.Substring(1,fullAddress.Length-2);
-						}
-						else if (double.TryParse(fullAddress, NumberStyles.Number, CultureInfo.InvariantCulture, out value))
-						{
-							namedRange.NameValue = value;
-						}
-						else
-						{
+                    if (addressType == ExcelAddressBase.AddressType.Invalid || addressType == ExcelAddressBase.AddressType.InternalName || addressType == ExcelAddressBase.AddressType.ExternalName || addressType==ExcelAddressBase.AddressType.Formula || addressType==ExcelAddressBase.AddressType.ExternalAddress)    //A value or a formula
+                    {
+                        double value;
+                        range = new ExcelRangeBase(this, nameWorksheet, elem.GetAttribute("name"), true);
+                        if (nameWorksheet == null)
+                        {
+                            namedRange = _names.Add(elem.GetAttribute("name"), range);
+                        }
+                        else
+                        {
+                            namedRange = nameWorksheet.Names.Add(elem.GetAttribute("name"), range);
+                        }
+                        
+                        if (Utils.ConvertUtil._invariantCompareInfo.IsPrefix(fullAddress, "\"")) //String value
+                        {
+                            namedRange.NameValue = fullAddress.Substring(1,fullAddress.Length-2);
+                        }
+                        else if (double.TryParse(fullAddress, NumberStyles.Number, CultureInfo.InvariantCulture, out value))
+                        {
+                            namedRange.NameValue = value;
+                        }
+                        else
+                        {
                             //if (addressType == ExcelAddressBase.AddressType.ExternalAddress || addressType == ExcelAddressBase.AddressType.ExternalName)
                             //{
                             //    var r = new ExcelAddress(fullAddress);
@@ -243,33 +243,33 @@ namespace OfficeOpenXml
                             //{
                                 namedRange.NameFormula = fullAddress;
                             //}
-						}
-					}
-					else
-					{
-						ExcelAddress addr = new ExcelAddress(fullAddress, _package, null);
-						if (localSheetID > -1)
-						{
-							if (string.IsNullOrEmpty(addr._ws))
-							{
-								namedRange = Worksheets[localSheetID + _package._worksheetAdd].Names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, Worksheets[localSheetID + _package._worksheetAdd], fullAddress, false));
-							}
-							else
-							{
-								namedRange = Worksheets[localSheetID + _package._worksheetAdd].Names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, Worksheets[addr._ws], fullAddress, false));
-							}
-						}
-						else
-						{
-							var ws = Worksheets[addr._ws];
-							namedRange = _names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, ws, fullAddress, false));
-						}
-					}
-					if (elem.GetAttribute("hidden") == "1" && namedRange != null) namedRange.IsNameHidden = true;
-					if(!string.IsNullOrEmpty(elem.GetAttribute("comment"))) namedRange.NameComment=elem.GetAttribute("comment");
-				}
-			}
-		}
+                        }
+                    }
+                    else
+                    {
+                        ExcelAddress addr = new ExcelAddress(fullAddress, _package, null);
+                        if (localSheetID > -1)
+                        {
+                            if (string.IsNullOrEmpty(addr._ws))
+                            {
+                                namedRange = Worksheets[localSheetID + _package._worksheetAdd].Names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, Worksheets[localSheetID + _package._worksheetAdd], fullAddress, false));
+                            }
+                            else
+                            {
+                                namedRange = Worksheets[localSheetID + _package._worksheetAdd].Names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, Worksheets[addr._ws], fullAddress, false));
+                            }
+                        }
+                        else
+                        {
+                            var ws = Worksheets[addr._ws];
+                            namedRange = _names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, ws, fullAddress, false));
+                        }
+                    }
+                    if (elem.GetAttribute("hidden") == "1" && namedRange != null) namedRange.IsNameHidden = true;
+                    if(!string.IsNullOrEmpty(elem.GetAttribute("comment"))) namedRange.NameComment=elem.GetAttribute("comment");
+                }
+            }
+        }
         #region Worksheets
         /// <summary>
         /// Provides access to all the worksheets in the workbook.
@@ -277,36 +277,36 @@ namespace OfficeOpenXml
         /// Default is 1 for .Net 3.5 and .Net 4 and 0 for .Net Core.
         /// </summary>
         public ExcelWorksheets Worksheets
-		{
-			get
-			{
-				if (_worksheets == null)
-				{
-					var sheetsNode = _workbookXml.DocumentElement.SelectSingleNode("d:sheets", _namespaceManager);
-					if (sheetsNode == null)
-					{
-						sheetsNode = CreateNode("d:sheets");
-					}
-					
-					_worksheets = new ExcelWorksheets(_package, _namespaceManager, sheetsNode);
-				}
-				return (_worksheets);
-			}
-		}
-		#endregion
+        {
+            get
+            {
+                if (_worksheets == null)
+                {
+                    var sheetsNode = _workbookXml.DocumentElement.SelectSingleNode("d:sheets", _namespaceManager);
+                    if (sheetsNode == null)
+                    {
+                        sheetsNode = CreateNode("d:sheets");
+                    }
+                    
+                    _worksheets = new ExcelWorksheets(_package, _namespaceManager, sheetsNode);
+                }
+                return (_worksheets);
+            }
+        }
+        #endregion
 
-		/// <summary>
-		/// Provides access to named ranges
-		/// </summary>
-		public ExcelNamedRangeCollection Names
-		{
-			get
-			{
-				return _names;
-			}
-		}
-		#region Workbook Properties
-		decimal _standardFontWidth = decimal.MinValue;
+        /// <summary>
+        /// Provides access to named ranges
+        /// </summary>
+        public ExcelNamedRangeCollection Names
+        {
+            get
+            {
+                return _names;
+            }
+        }
+        #region Workbook Properties
+        decimal _standardFontWidth = decimal.MinValue;
         string _fontID = "";
         internal FormulaParser FormulaParser
         {
@@ -320,30 +320,30 @@ namespace OfficeOpenXml
             }
         }
 
-	    public FormulaParserManager FormulaParserManager
-	    {
-	        get
-	        {
-	            if (_parserManager == null)
-	            {
-	                _parserManager = new FormulaParserManager(FormulaParser);
-	            }
-	            return _parserManager;
-	        }
-	    }
+        public FormulaParserManager FormulaParserManager
+        {
+            get
+            {
+                if (_parserManager == null)
+                {
+                    _parserManager = new FormulaParserManager(FormulaParser);
+                }
+                return _parserManager;
+            }
+        }
         /// <summary>
-		/// Max font width for the workbook
+        /// Max font width for the workbook
         /// <remarks>This method uses GDI. If you use Asure or another environment that does not support GDI, you have to set this value manually if you don't use the standard Calibri font</remarks>
-		/// </summary>
-		public decimal MaxFontWidth 
-		{
-			get
-			{
+        /// </summary>
+        public decimal MaxFontWidth 
+        {
+            get
+            {
                 var ix = Styles.NamedStyles.FindIndexByID("Normal");
                 if (ix >= 0)
                 {
                     if (_standardFontWidth == decimal.MinValue || _fontID != Styles.NamedStyles[ix].Style.Font.Id)
-				    {
+                    {
                         var font = Styles.NamedStyles[ix].Style.Font;
                         try
                         {
@@ -361,15 +361,15 @@ namespace OfficeOpenXml
                     _standardFontWidth = 7; //Calibri 11
                 }
                 return _standardFontWidth;
-			}
+            }
             set
             {
                 _standardFontWidth = value;
             }
-		}
+        }
 
-	    internal static decimal GetWidthPixels(string fontName, float fontSize)
-	    {
+        internal static decimal GetWidthPixels(string fontName, float fontSize)
+        {
             Dictionary<float, FontSizeInfo> font;
             if (FontSize.FontHeights.ContainsKey(fontName))
             {
@@ -409,37 +409,37 @@ namespace OfficeOpenXml
             }
         }
 
-	    ExcelProtection _protection = null;
-		/// <summary>
-		/// Access properties to protect or unprotect a workbook
-		/// </summary>
-		public ExcelProtection Protection
-		{
-			get
-			{
-				if (_protection == null)
-				{
-					_protection = new ExcelProtection(NameSpaceManager, TopNode, this);
-					_protection.SchemaNodeOrder = SchemaNodeOrder;
-				}
-				return _protection;
-			}
-		}        
-		ExcelWorkbookView _view = null;
-		/// <summary>
-		/// Access to workbook view properties
-		/// </summary>
-		public ExcelWorkbookView View
-		{
-			get
-			{
-				if (_view == null)
-				{
-					_view = new ExcelWorkbookView(NameSpaceManager, TopNode, this);
-				}
-				return _view;
-			}
-		}
+        ExcelProtection _protection = null;
+        /// <summary>
+        /// Access properties to protect or unprotect a workbook
+        /// </summary>
+        public ExcelProtection Protection
+        {
+            get
+            {
+                if (_protection == null)
+                {
+                    _protection = new ExcelProtection(NameSpaceManager, TopNode, this);
+                    _protection.SchemaNodeOrder = SchemaNodeOrder;
+                }
+                return _protection;
+            }
+        }        
+        ExcelWorkbookView _view = null;
+        /// <summary>
+        /// Access to workbook view properties
+        /// </summary>
+        public ExcelWorkbookView View
+        {
+            get
+            {
+                if (_view == null)
+                {
+                    _view = new ExcelWorkbookView(NameSpaceManager, TopNode, this);
+                }
+                return _view;
+            }
+        }
         ExcelVbaProject _vba = null;
         /// <summary>
         /// A reference to the VBA project.
@@ -473,40 +473,40 @@ namespace OfficeOpenXml
                         
             _vba = new ExcelVbaProject(this);
             _vba.Create();
-				}
-		/// <summary>
-		/// URI to the workbook inside the package
-		/// </summary>
-		internal Uri WorkbookUri { get; private set; }
-		/// <summary>
+                }
+        /// <summary>
+        /// URI to the workbook inside the package
+        /// </summary>
+        internal Uri WorkbookUri { get; private set; }
+        /// <summary>
         /// URI to the styles inside the package
-		/// </summary>
-		internal Uri StylesUri { get; private set; }
-		/// <summary>
+        /// </summary>
+        internal Uri StylesUri { get; private set; }
+        /// <summary>
         /// URI to the shared strings inside the package
-		/// </summary>
-		internal Uri SharedStringsUri { get; private set; }
-		/// <summary>
-		/// Returns a reference to the workbook's part within the package
-		/// </summary>
-		internal Packaging.ZipPackagePart Part { get { return (_package.Package.GetPart(WorkbookUri)); } }
-		
-		#region WorkbookXml
-		private XmlDocument _workbookXml;
-		/// <summary>
-		/// Provides access to the XML data representing the workbook in the package.
-		/// </summary>
-		public XmlDocument WorkbookXml
-		{
-			get
-			{
-				if (_workbookXml == null)
-				{
-					CreateWorkbookXml(_namespaceManager);
-				}
-				return (_workbookXml);
-			}
-		}
+        /// </summary>
+        internal Uri SharedStringsUri { get; private set; }
+        /// <summary>
+        /// Returns a reference to the workbook's part within the package
+        /// </summary>
+        internal Packaging.ZipPackagePart Part { get { return (_package.Package.GetPart(WorkbookUri)); } }
+        
+        #region WorkbookXml
+        private XmlDocument _workbookXml;
+        /// <summary>
+        /// Provides access to the XML data representing the workbook in the package.
+        /// </summary>
+        public XmlDocument WorkbookXml
+        {
+            get
+            {
+                if (_workbookXml == null)
+                {
+                    CreateWorkbookXml(_namespaceManager);
+                }
+                return (_workbookXml);
+            }
+        }
         const string codeModuleNamePath = "d:workbookPr/@codeName";
         internal string CodeModuleName
         {
@@ -596,170 +596,170 @@ namespace OfficeOpenXml
         }
      
        
-		/// <summary>
-		/// Create or read the XML for the workbook.
-		/// </summary>
-		private void CreateWorkbookXml(XmlNamespaceManager namespaceManager)
-		{
-			if (_package.Package.PartExists(WorkbookUri))
-				_workbookXml = _package.GetXmlFromUri(WorkbookUri);
-			else
-			{
-				// create a new workbook part and add to the package
-				Packaging.ZipPackagePart partWorkbook = _package.Package.CreatePart(WorkbookUri, @"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml", _package.Compression);
+        /// <summary>
+        /// Create or read the XML for the workbook.
+        /// </summary>
+        private void CreateWorkbookXml(XmlNamespaceManager namespaceManager)
+        {
+            if (_package.Package.PartExists(WorkbookUri))
+                _workbookXml = _package.GetXmlFromUri(WorkbookUri);
+            else
+            {
+                // create a new workbook part and add to the package
+                Packaging.ZipPackagePart partWorkbook = _package.Package.CreatePart(WorkbookUri, @"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml", _package.Compression);
 
-				// create the workbook
-				_workbookXml = new XmlDocument(namespaceManager.NameTable);                
-				
-				_workbookXml.PreserveWhitespace = ExcelPackage.preserveWhitespace;
-				// create the workbook element
-				XmlElement wbElem = _workbookXml.CreateElement("workbook", ExcelPackage.schemaMain);
+                // create the workbook
+                _workbookXml = new XmlDocument(namespaceManager.NameTable);                
+                
+                _workbookXml.PreserveWhitespace = ExcelPackage.preserveWhitespace;
+                // create the workbook element
+                XmlElement wbElem = _workbookXml.CreateElement("workbook", ExcelPackage.schemaMain);
 
-				// Add the relationships namespace
-				wbElem.SetAttribute("xmlns:r", ExcelPackage.schemaRelationships);
+                // Add the relationships namespace
+                wbElem.SetAttribute("xmlns:r", ExcelPackage.schemaRelationships);
 
-				_workbookXml.AppendChild(wbElem);
+                _workbookXml.AppendChild(wbElem);
 
-				// create the bookViews and workbooks element
-				XmlElement bookViews = _workbookXml.CreateElement("bookViews", ExcelPackage.schemaMain);
-				wbElem.AppendChild(bookViews);
-				XmlElement workbookView = _workbookXml.CreateElement("workbookView", ExcelPackage.schemaMain);
-				bookViews.AppendChild(workbookView);
+                // create the bookViews and workbooks element
+                XmlElement bookViews = _workbookXml.CreateElement("bookViews", ExcelPackage.schemaMain);
+                wbElem.AppendChild(bookViews);
+                XmlElement workbookView = _workbookXml.CreateElement("workbookView", ExcelPackage.schemaMain);
+                bookViews.AppendChild(workbookView);
 
-				// save it to the package
-				StreamWriter stream = new StreamWriter(partWorkbook.GetStream(FileMode.Create, FileAccess.Write));
-				_workbookXml.Save(stream);
-				//stream.Close();
-				_package.Package.Flush();
-			}
-		}
-		#endregion
-		#region StylesXml
-		private XmlDocument _stylesXml;
-		/// <summary>
-		/// Provides access to the XML data representing the styles in the package. 
-		/// </summary>
-		public XmlDocument StylesXml
-		{
-			get
-			{
-				if (_stylesXml == null)
-				{
-					if (_package.Package.PartExists(StylesUri))
-						_stylesXml = _package.GetXmlFromUri(StylesUri);
-					else
-					{
-						// create a new styles part and add to the package
-						Packaging.ZipPackagePart part = _package.Package.CreatePart(StylesUri, @"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml", _package.Compression);
-						// create the style sheet
+                // save it to the package
+                StreamWriter stream = new StreamWriter(partWorkbook.GetStream(FileMode.Create, FileAccess.Write));
+                _workbookXml.Save(stream);
+                //stream.Close();
+                _package.Package.Flush();
+            }
+        }
+        #endregion
+        #region StylesXml
+        private XmlDocument _stylesXml;
+        /// <summary>
+        /// Provides access to the XML data representing the styles in the package. 
+        /// </summary>
+        public XmlDocument StylesXml
+        {
+            get
+            {
+                if (_stylesXml == null)
+                {
+                    if (_package.Package.PartExists(StylesUri))
+                        _stylesXml = _package.GetXmlFromUri(StylesUri);
+                    else
+                    {
+                        // create a new styles part and add to the package
+                        Packaging.ZipPackagePart part = _package.Package.CreatePart(StylesUri, @"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml", _package.Compression);
+                        // create the style sheet
 
-						StringBuilder xml = new StringBuilder("<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
-						xml.Append("<numFmts />");
-						xml.Append("<fonts count=\"1\"><font><sz val=\"11\" /><name val=\"Calibri\" /></font></fonts>");
-						xml.Append("<fills><fill><patternFill patternType=\"none\" /></fill><fill><patternFill patternType=\"gray125\" /></fill></fills>");
-						xml.Append("<borders><border><left /><right /><top /><bottom /><diagonal /></border></borders>");
-						xml.Append("<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" /></cellStyleXfs>");
-						xml.Append("<cellXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" xfId=\"0\" /></cellXfs>");
-						xml.Append("<cellStyles><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\" /></cellStyles>");
+                        StringBuilder xml = new StringBuilder("<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
+                        xml.Append("<numFmts />");
+                        xml.Append("<fonts count=\"1\"><font><sz val=\"11\" /><name val=\"Calibri\" /></font></fonts>");
+                        xml.Append("<fills><fill><patternFill patternType=\"none\" /></fill><fill><patternFill patternType=\"gray125\" /></fill></fills>");
+                        xml.Append("<borders><border><left /><right /><top /><bottom /><diagonal /></border></borders>");
+                        xml.Append("<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" /></cellStyleXfs>");
+                        xml.Append("<cellXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" xfId=\"0\" /></cellXfs>");
+                        xml.Append("<cellStyles><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\" /></cellStyles>");
                         xml.Append("<dxfs count=\"0\" />");
                         xml.Append("</styleSheet>");
-						
-						_stylesXml = new XmlDocument();
-						_stylesXml.LoadXml(xml.ToString());
-						
-						//Save it to the package
-						StreamWriter stream = new StreamWriter(part.GetStream(FileMode.Create, FileAccess.Write));
-
-						_stylesXml.Save(stream);
-						//stream.Close();
-						_package.Package.Flush();
-
-						// create the relationship between the workbook and the new shared strings part
-						_package.Workbook.Part.CreateRelationship(UriHelper.GetRelativeUri(WorkbookUri, StylesUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/styles");
-						_package.Package.Flush();
-					}
-				}
-				return (_stylesXml);
-			}
-			set
-			{
-				_stylesXml = value;
-			}
-		}
-		/// <summary>
-		/// Package styles collection. Used internally to access style data.
-		/// </summary>
-		public ExcelStyles Styles
-		{
-			get
-			{
-				if (_styles == null)
-				{
-					_styles = new ExcelStyles(NameSpaceManager, StylesXml, this);
-				}
-				return _styles;
-			}
-		}
-		#endregion
-
-		#region Office Document Properties
-		/// <summary>
-		/// The office document properties
-		/// </summary>
-		public OfficeProperties Properties
-		{
-			get 
-			{
-				if (_properties == null)
-				{
-					//  Create a NamespaceManager to handle the default namespace, 
-					//  and create a prefix for the default namespace:                   
-					_properties = new OfficeProperties(_package, NameSpaceManager);
-				}
-				return _properties;
-			}
-		}
-		#endregion
-
-		#region CalcMode
-		private string CALC_MODE_PATH = "d:calcPr/@calcMode";
-		/// <summary>
-		/// Calculation mode for the workbook.
-		/// </summary>
-		public ExcelCalcMode CalcMode
-		{
-			get
-			{
-				string calcMode = GetXmlNodeString(CALC_MODE_PATH);
-				switch (calcMode)
-				{
-					case "autoNoTable":
-						return ExcelCalcMode.AutomaticNoTable;
-					case "manual":
-						return ExcelCalcMode.Manual;
-					default:
-						return ExcelCalcMode.Automatic;
                         
-				}
-			}
-			set
-			{
-				switch (value)
-				{
-					case ExcelCalcMode.AutomaticNoTable:
-						SetXmlNodeString(CALC_MODE_PATH, "autoNoTable") ;
-						break;
-					case ExcelCalcMode.Manual:
-						SetXmlNodeString(CALC_MODE_PATH, "manual");
-						break;
-					default:
-						SetXmlNodeString(CALC_MODE_PATH, "auto");
-						break;
+                        _stylesXml = new XmlDocument();
+                        _stylesXml.LoadXml(xml.ToString());
+                        
+                        //Save it to the package
+                        StreamWriter stream = new StreamWriter(part.GetStream(FileMode.Create, FileAccess.Write));
 
-				}
-			}
-			#endregion
-		}
+                        _stylesXml.Save(stream);
+                        //stream.Close();
+                        _package.Package.Flush();
+
+                        // create the relationship between the workbook and the new shared strings part
+                        _package.Workbook.Part.CreateRelationship(UriHelper.GetRelativeUri(WorkbookUri, StylesUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/styles");
+                        _package.Package.Flush();
+                    }
+                }
+                return (_stylesXml);
+            }
+            set
+            {
+                _stylesXml = value;
+            }
+        }
+        /// <summary>
+        /// Package styles collection. Used internally to access style data.
+        /// </summary>
+        public ExcelStyles Styles
+        {
+            get
+            {
+                if (_styles == null)
+                {
+                    _styles = new ExcelStyles(NameSpaceManager, StylesXml, this);
+                }
+                return _styles;
+            }
+        }
+        #endregion
+
+        #region Office Document Properties
+        /// <summary>
+        /// The office document properties
+        /// </summary>
+        public OfficeProperties Properties
+        {
+            get 
+            {
+                if (_properties == null)
+                {
+                    //  Create a NamespaceManager to handle the default namespace, 
+                    //  and create a prefix for the default namespace:                   
+                    _properties = new OfficeProperties(_package, NameSpaceManager);
+                }
+                return _properties;
+            }
+        }
+        #endregion
+
+        #region CalcMode
+        private string CALC_MODE_PATH = "d:calcPr/@calcMode";
+        /// <summary>
+        /// Calculation mode for the workbook.
+        /// </summary>
+        public ExcelCalcMode CalcMode
+        {
+            get
+            {
+                string calcMode = GetXmlNodeString(CALC_MODE_PATH);
+                switch (calcMode)
+                {
+                    case "autoNoTable":
+                        return ExcelCalcMode.AutomaticNoTable;
+                    case "manual":
+                        return ExcelCalcMode.Manual;
+                    default:
+                        return ExcelCalcMode.Automatic;
+                        
+                }
+            }
+            set
+            {
+                switch (value)
+                {
+                    case ExcelCalcMode.AutomaticNoTable:
+                        SetXmlNodeString(CALC_MODE_PATH, "autoNoTable") ;
+                        break;
+                    case ExcelCalcMode.Manual:
+                        SetXmlNodeString(CALC_MODE_PATH, "manual");
+                        break;
+                    default:
+                        SetXmlNodeString(CALC_MODE_PATH, "auto");
+                        break;
+
+                }
+            }
+            #endregion
+        }
 
         private const string FULL_CALC_ON_LOAD_PATH = "d:calcPr/@fullCalcOnLoad";
         /// <summary>
@@ -767,30 +767,30 @@ namespace OfficeOpenXml
         /// <remarks>This property is always true for both new workbooks and loaded templates(on load). If this is not the wanted behavior set this property to false.</remarks>
         /// </summary>
         public bool FullCalcOnLoad
-	    {
-	        get
-	        {
+        {
+            get
+            {
                 return GetXmlNodeBool(FULL_CALC_ON_LOAD_PATH);   
-	        }
-	        set
-	        {
+            }
+            set
+            {
                 SetXmlNodeBool(FULL_CALC_ON_LOAD_PATH, value);
-	        }
-	    }
-		#endregion
-		#region Workbook Private Methods
-			
-		#region Save // Workbook Save
-		/// <summary>
-		/// Saves the workbook and all its components to the package.
-		/// For internal use only!
-		/// </summary>
-		internal void Save()  // Workbook Save
-		{
-			if (Worksheets.Count == 0)
-				throw new InvalidOperationException("The workbook must contain at least one worksheet");
+            }
+        }
+        #endregion
+        #region Workbook Private Methods
+            
+        #region Save // Workbook Save
+        /// <summary>
+        /// Saves the workbook and all its components to the package.
+        /// For internal use only!
+        /// </summary>
+        internal void Save()  // Workbook Save
+        {
+            if (Worksheets.Count == 0)
+                throw new InvalidOperationException("The workbook must contain at least one worksheet");
 
-			DeleteCalcChain();
+            DeleteCalcChain();
 
             if (_vba == null && !_package.Package.PartExists(new Uri(ExcelVbaProject.PartUri, UriKind.Relative)))
             {
@@ -806,36 +806,36 @@ namespace OfficeOpenXml
                     Part.ContentType = ExcelPackage.contentTypeWorkbookMacroEnabled;
                 }
             }
-			
+            
             UpdateDefinedNamesXml();
 
-			// save the workbook
-			if (_workbookXml != null)
-			{
-				_package.SavePart(WorkbookUri, _workbookXml);
-			}
+            // save the workbook
+            if (_workbookXml != null)
+            {
+                _package.SavePart(WorkbookUri, _workbookXml);
+            }
 
-			// save the properties of the workbook
-			if (_properties != null)
-			{
-				_properties.Save();
-			}
+            // save the properties of the workbook
+            if (_properties != null)
+            {
+                _properties.Save();
+            }
 
-			// save the style sheet
-			Styles.UpdateXml();
-			_package.SavePart(StylesUri, _stylesXml);
+            // save the style sheet
+            Styles.UpdateXml();
+            _package.SavePart(StylesUri, _stylesXml);
 
-			// save all the open worksheets
-			var isProtected = Protection.LockWindows || Protection.LockStructure;
-			foreach (ExcelWorksheet worksheet in Worksheets)
-			{
-				if (isProtected && Protection.LockWindows)
-				{
-					worksheet.View.WindowProtection = true;
-				}
-				worksheet.Save();
+            // save all the open worksheets
+            var isProtected = Protection.LockWindows || Protection.LockStructure;
+            foreach (ExcelWorksheet worksheet in Worksheets)
+            {
+                if (isProtected && Protection.LockWindows)
+                {
+                    worksheet.View.WindowProtection = true;
+                }
+                worksheet.Save();
                 worksheet.Part.SaveHandler = worksheet.SaveHandler;
-			}
+            }
 
             // Issue 15252: save SharedStrings only once
             Packaging.ZipPackagePart part;
@@ -851,9 +851,9 @@ namespace OfficeOpenXml
 
             part.SaveHandler = SaveSharedStringHandler;
             //UpdateSharedStringsXml();
-			
-			// Data validation
-			ValidateDataValidations();
+            
+            // Data validation
+            ValidateDataValidations();
 
             //VBA
             if (_vba!=null)
@@ -861,40 +861,40 @@ namespace OfficeOpenXml
                 VbaProject.Save();
             }
 
-		}
-		private void DeleteCalcChain()
-		{
-			//Remove the calc chain if it exists.
-			Uri uriCalcChain = new Uri("/xl/calcChain.xml", UriKind.Relative);
-			if (_package.Package.PartExists(uriCalcChain))
-			{
-				Uri calcChain = new Uri("calcChain.xml", UriKind.Relative);
-				foreach (var relationship in _package.Workbook.Part.GetRelationships())
-				{
-					if (relationship.TargetUri == calcChain)
-					{
-						_package.Workbook.Part.DeleteRelationship(relationship.Id);
-						break;
-					}
-				}
-				// delete the calcChain part
-				_package.Package.DeletePart(uriCalcChain);
-			}
-		}
+        }
+        private void DeleteCalcChain()
+        {
+            //Remove the calc chain if it exists.
+            Uri uriCalcChain = new Uri("/xl/calcChain.xml", UriKind.Relative);
+            if (_package.Package.PartExists(uriCalcChain))
+            {
+                Uri calcChain = new Uri("calcChain.xml", UriKind.Relative);
+                foreach (var relationship in _package.Workbook.Part.GetRelationships())
+                {
+                    if (relationship.TargetUri == calcChain)
+                    {
+                        _package.Workbook.Part.DeleteRelationship(relationship.Id);
+                        break;
+                    }
+                }
+                // delete the calcChain part
+                _package.Package.DeletePart(uriCalcChain);
+            }
+        }
 
-		private void ValidateDataValidations()
-		{
-			foreach (var sheet in _package.Workbook.Worksheets)
-			{
+        private void ValidateDataValidations()
+        {
+            foreach (var sheet in _package.Workbook.Worksheets)
+            {
                 if (!(sheet is ExcelChartsheet))
                 {
                     sheet.DataValidations.ValidateAll();
                 }
-			}
-		}
+            }
+        }
 
         private void SaveSharedStringHandler(ZipOutputStream stream, CompressionLevel compressionLevel, string fileName)
-		{
+        {
             //Packaging.ZipPackagePart stringPart;
             //if (_package.Package.PartExists(SharedStringsUri))
             //{
@@ -906,7 +906,7 @@ namespace OfficeOpenXml
                   //Part.CreateRelationship(UriHelper.GetRelativeUri(WorkbookUri, SharedStringsUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/sharedStrings");
             //}
 
-			//StreamWriter sw = new StreamWriter(stringPart.GetStream(FileMode.Create, FileAccess.Write));
+            //StreamWriter sw = new StreamWriter(stringPart.GetStream(FileMode.Create, FileAccess.Write));
             //Init Zip
             stream.CompressionLevel = (OfficeOpenXml.Packaging.Ionic.Zlib.CompressionLevel)compressionLevel;
             stream.PutNextEntry(fileName);
@@ -914,75 +914,75 @@ namespace OfficeOpenXml
             var cache = new StringBuilder();            
             var sw = new StreamWriter(stream);
             cache.AppendFormat("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?><sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"{0}\" uniqueCount=\"{0}\">", _sharedStrings.Count);
-			foreach (string t in _sharedStrings.Keys)
-			{
+            foreach (string t in _sharedStrings.Keys)
+            {
 
-				SharedStringItem ssi = _sharedStrings[t];
-				if (ssi.isRichText)
-				{
+                SharedStringItem ssi = _sharedStrings[t];
+                if (ssi.isRichText)
+                {
                     cache.Append("<si>");
                     ConvertUtil.ExcelEncodeString(cache, t);
                     cache.Append("</si>");
-				}
-				else
-				{
+                }
+                else
+                {
                     if (t.Length > 0 && (t[0] == ' ' || t[t.Length - 1] == ' ' || t.Contains("  ") || t.Contains("\t") || t.Contains("\n") || t.Contains("\n")))   //Fixes issue 14849
-					{
+                    {
                         cache.Append("<si><t xml:space=\"preserve\">");
-					}
-					else
-					{
+                    }
+                    else
+                    {
                         cache.Append("<si><t>");
-					}
+                    }
                     ConvertUtil.ExcelEncodeString(cache, ConvertUtil.ExcelEscapeString(t));
                     cache.Append("</t></si>");
-				}
+                }
                 if (cache.Length > 0x600000)
                 {
                     sw.Write(cache.ToString());
                     cache = new StringBuilder();            
                 }
-			}
+            }
             cache.Append("</sst>");
             sw.Write(cache.ToString());
             sw.Flush();
             // Issue 15252: Save SharedStrings only once
             //Part.CreateRelationship(UriHelper.GetRelativeUri(WorkbookUri, SharedStringsUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/sharedStrings");
-		}
-		private void UpdateDefinedNamesXml()
-		{
-			try
-			{
+        }
+        private void UpdateDefinedNamesXml()
+        {
+            try
+            {
                 XmlNode top = WorkbookXml.SelectSingleNode("//d:definedNames", NameSpaceManager);
-				if (!ExistsNames())
-				{
-					if (top != null) TopNode.RemoveChild(top);
-					return;
-				}
-				else
-				{
-					if (top == null)
-					{
-						CreateNode("d:definedNames");
-						top = WorkbookXml.SelectSingleNode("//d:definedNames", NameSpaceManager);
-					}
-					else
-					{
-						top.RemoveAll();
-					}
-					foreach (ExcelNamedRange name in _names)
-					{
+                if (!ExistsNames())
+                {
+                    if (top != null) TopNode.RemoveChild(top);
+                    return;
+                }
+                else
+                {
+                    if (top == null)
+                    {
+                        CreateNode("d:definedNames");
+                        top = WorkbookXml.SelectSingleNode("//d:definedNames", NameSpaceManager);
+                    }
+                    else
+                    {
+                        top.RemoveAll();
+                    }
+                    foreach (ExcelNamedRange name in _names)
+                    {
 
-						XmlElement elem = WorkbookXml.CreateElement("definedName", ExcelPackage.schemaMain);
-						top.AppendChild(elem);
-						elem.SetAttribute("name", name.Name);
-						if (name.IsNameHidden) elem.SetAttribute("hidden", "1");
-						if (!string.IsNullOrEmpty(name.NameComment)) elem.SetAttribute("comment", name.NameComment);
-						SetNameElement(name, elem);
-					}
-				}
-				foreach (ExcelWorksheet ws in _worksheets)
-				{
+                        XmlElement elem = WorkbookXml.CreateElement("definedName", ExcelPackage.schemaMain);
+                        top.AppendChild(elem);
+                        elem.SetAttribute("name", name.Name);
+                        if (name.IsNameHidden) elem.SetAttribute("hidden", "1");
+                        if (!string.IsNullOrEmpty(name.NameComment)) elem.SetAttribute("comment", name.NameComment);
+                        SetNameElement(name, elem);
+                    }
+                }
+                foreach (ExcelWorksheet ws in _worksheets)
+                {
                     if (!(ws is ExcelChartsheet))
                     {
                         foreach (ExcelNamedRange name in ws.Names)
@@ -996,132 +996,132 @@ namespace OfficeOpenXml
                             SetNameElement(name, elem);
                         }
                     }
-				}
-			}
-			catch (Exception ex)
-			{
-				throw new Exception("Internal error updating named ranges ",ex);
-			}
-		}
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Internal error updating named ranges ",ex);
+            }
+        }
 
-		private void SetNameElement(ExcelNamedRange name, XmlElement elem)
-		{
-			if (name.IsName)
-			{
-				if (string.IsNullOrEmpty(name.NameFormula))
-				{
-					if ((TypeCompat.IsPrimitive(name.NameValue) || name.NameValue is double || name.NameValue is decimal))
-					{
-						elem.InnerText = Convert.ToDouble(name.NameValue, CultureInfo.InvariantCulture).ToString("R15", CultureInfo.InvariantCulture); 
-					}
-					else if (name.NameValue is DateTime)
-					{
-						elem.InnerText = ((DateTime)name.NameValue).ToOADate().ToString(CultureInfo.InvariantCulture);
-					}
-					else
-					{
-						elem.InnerText = "\"" + name.NameValue.ToString() + "\"";
-					}                                
-				}
-				else
-				{
-					elem.InnerText = name.NameFormula;
-				}
-			}
-			else
-			{
+        private void SetNameElement(ExcelNamedRange name, XmlElement elem)
+        {
+            if (name.IsName)
+            {
+                if (string.IsNullOrEmpty(name.NameFormula))
+                {
+                    if ((TypeCompat.IsPrimitive(name.NameValue) || name.NameValue is double || name.NameValue is decimal))
+                    {
+                        elem.InnerText = Convert.ToDouble(name.NameValue, CultureInfo.InvariantCulture).ToString("R15", CultureInfo.InvariantCulture); 
+                    }
+                    else if (name.NameValue is DateTime)
+                    {
+                        elem.InnerText = ((DateTime)name.NameValue).ToOADate().ToString(CultureInfo.InvariantCulture);
+                    }
+                    else
+                    {
+                        elem.InnerText = "\"" + name.NameValue.ToString() + "\"";
+                    }                                
+                }
+                else
+                {
+                    elem.InnerText = name.NameFormula;
+                }
+            }
+            else
+            {
                 elem.InnerText = name.FullAddressAbsolute;
-			}
-		}
-		/// <summary>
-		/// Is their any names in the workbook or in the sheets.
-		/// </summary>
-		/// <returns>?</returns>
-		private bool ExistsNames()
-		{
-			if (_names.Count == 0)
-			{
-				foreach (ExcelWorksheet ws in Worksheets)
-				{
+            }
+        }
+        /// <summary>
+        /// Is their any names in the workbook or in the sheets.
+        /// </summary>
+        /// <returns>?</returns>
+        private bool ExistsNames()
+        {
+            if (_names.Count == 0)
+            {
+                foreach (ExcelWorksheet ws in Worksheets)
+                {
                     if (ws is ExcelChartsheet) continue;
                     if(ws.Names.Count>0)
-					{
-						return true;
-					}
-				}
-			}
-			else
-			{
-				return true;
-			}
-			return false;
-		}        
-		#endregion
+                    {
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                return true;
+            }
+            return false;
+        }        
+        #endregion
 
-		#endregion
-		internal bool ExistsTableName(string Name)
-		{
-			foreach (var ws in Worksheets)
-			{
-				if(ws.Tables._tableNames.ContainsKey(Name))
-				{
-					return true;
-				}
-			}
-			return false;
-		}
-		internal bool ExistsPivotTableName(string Name)
-		{
-			foreach (var ws in Worksheets)
-			{
-				if (ws.PivotTables._pivotTableNames.ContainsKey(Name))
-				{
-					return true;
-				}
-			}
-			return false;
-		}
-		internal void AddPivotTable(string cacheID, Uri defUri)
-		{
-			CreateNode("d:pivotCaches");
+        #endregion
+        internal bool ExistsTableName(string Name)
+        {
+            foreach (var ws in Worksheets)
+            {
+                if(ws.Tables._tableNames.ContainsKey(Name))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        internal bool ExistsPivotTableName(string Name)
+        {
+            foreach (var ws in Worksheets)
+            {
+                if (ws.PivotTables._pivotTableNames.ContainsKey(Name))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        internal void AddPivotTable(string cacheID, Uri defUri)
+        {
+            CreateNode("d:pivotCaches");
 
-			XmlElement item = WorkbookXml.CreateElement("pivotCache", ExcelPackage.schemaMain);
-			item.SetAttribute("cacheId", cacheID);
-			var rel = Part.CreateRelationship(UriHelper.ResolvePartUri(WorkbookUri, defUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/pivotCacheDefinition");
-			item.SetAttribute("id", ExcelPackage.schemaRelationships, rel.Id);
+            XmlElement item = WorkbookXml.CreateElement("pivotCache", ExcelPackage.schemaMain);
+            item.SetAttribute("cacheId", cacheID);
+            var rel = Part.CreateRelationship(UriHelper.ResolvePartUri(WorkbookUri, defUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/pivotCacheDefinition");
+            item.SetAttribute("id", ExcelPackage.schemaRelationships, rel.Id);
 
-			var pivotCaches = WorkbookXml.SelectSingleNode("//d:pivotCaches", NameSpaceManager);
-			pivotCaches.AppendChild(item);
-		}
-		internal List<string> _externalReferences = new List<string>();
+            var pivotCaches = WorkbookXml.SelectSingleNode("//d:pivotCaches", NameSpaceManager);
+            pivotCaches.AppendChild(item);
+        }
+        internal List<string> _externalReferences = new List<string>();
         //internal bool _isCalculated=false;
-		internal void GetExternalReferences()
-		{
-			XmlNodeList nl = WorkbookXml.SelectNodes("//d:externalReferences/d:externalReference", NameSpaceManager);
-			if (nl != null)
-			{
-				foreach (XmlElement elem in nl)
-				{
-					string rID = elem.GetAttribute("r:id");
-					var rel = Part.GetRelationship(rID);
-					var part = _package.Package.GetPart(UriHelper.ResolvePartUri(rel.SourceUri, rel.TargetUri));
-					XmlDocument xmlExtRef = new XmlDocument();
+        internal void GetExternalReferences()
+        {
+            XmlNodeList nl = WorkbookXml.SelectNodes("//d:externalReferences/d:externalReference", NameSpaceManager);
+            if (nl != null)
+            {
+                foreach (XmlElement elem in nl)
+                {
+                    string rID = elem.GetAttribute("r:id");
+                    var rel = Part.GetRelationship(rID);
+                    var part = _package.Package.GetPart(UriHelper.ResolvePartUri(rel.SourceUri, rel.TargetUri));
+                    XmlDocument xmlExtRef = new XmlDocument();
                     LoadXmlSafe(xmlExtRef, part.GetStream()); 
 
-					XmlElement book=xmlExtRef.SelectSingleNode("//d:externalBook", NameSpaceManager) as XmlElement;
-					if(book!=null)
-					{
-						string rId_ExtRef = book.GetAttribute("r:id");
-						var rel_extRef = part.GetRelationship(rId_ExtRef);
-						if (rel_extRef != null)
-						{
-							_externalReferences.Add(rel_extRef.TargetUri.OriginalString);
-						}
+                    XmlElement book=xmlExtRef.SelectSingleNode("//d:externalBook", NameSpaceManager) as XmlElement;
+                    if(book!=null)
+                    {
+                        string rId_ExtRef = book.GetAttribute("r:id");
+                        var rel_extRef = part.GetRelationship(rId_ExtRef);
+                        if (rel_extRef != null)
+                        {
+                            _externalReferences.Add(rel_extRef.TargetUri.OriginalString);
+                        }
 
-					}
-				}
-			}
-		}
+                    }
+                }
+            }
+        }
 
         public void Dispose()
         {

--- a/EPPlus/ExcelWorkbookView.cs
+++ b/EPPlus/ExcelWorkbookView.cs
@@ -51,10 +51,10 @@ namespace OfficeOpenXml
         /// <param name="wb"></param>
         internal ExcelWorkbookView(XmlNamespaceManager ns, XmlNode node, ExcelWorkbook wb) :
             base(ns, node)
-		{
+        {
             SchemaNodeOrder = wb.SchemaNodeOrder;
-		}
-		#endregion
+        }
+        #endregion
         const string LEFT_PATH="d:bookViews/d:workbookView/@xWindow";
         /// <summary>
         /// Position of the upper left corner of the workbook window. In twips.

--- a/EPPlus/ExcelWorksheet.cs
+++ b/EPPlus/ExcelWorksheet.cs
@@ -117,8 +117,8 @@ namespace OfficeOpenXml
         }
     }
     /// <summary>
-	/// Represents an Excel worksheet and provides access to its properties and methods
-	/// </summary>
+    /// Represents an Excel worksheet and provides access to its properties and methods
+    /// </summary>
     public class ExcelWorksheet : XmlHelper, IEqualityComparer<ExcelWorksheet>, IDisposable
     {
         internal class Formulas
@@ -597,8 +597,8 @@ namespace OfficeOpenXml
         }
         double _defaultRowHeight = double.NaN;
         /// <summary>
-		/// Get/set the default height of all rows in the worksheet
-		/// </summary>
+        /// Get/set the default height of all rows in the worksheet
+        /// </summary>
         public double DefaultRowHeight
         {
             get
@@ -1677,11 +1677,11 @@ namespace OfficeOpenXml
             }
         }
         /// <summary>
-		/// Provides access to an individual row within the worksheet so you can set its properties.
-		/// </summary>
-		/// <param name="row">The row number in the worksheet</param>
-		/// <returns></returns>
-		public ExcelRow Row(int row)
+        /// Provides access to an individual row within the worksheet so you can set its properties.
+        /// </summary>
+        /// <param name="row">The row number in the worksheet</param>
+        /// <returns></returns>
+        public ExcelRow Row(int row)
         {
             //ExcelRow r;
             //ulong id = ExcelRow.GetRowID(_sheetID, row);
@@ -1862,13 +1862,13 @@ namespace OfficeOpenXml
             InsertRow(rowFrom, rows, 0);
         }
         /// <summary>
-		/// Inserts a new row into the spreadsheet.  Existing rows below the position are 
-		/// shifted down.  All formula are updated to take account of the new row.
-		/// </summary>
+        /// Inserts a new row into the spreadsheet.  Existing rows below the position are 
+        /// shifted down.  All formula are updated to take account of the new row.
+        /// </summary>
         /// <param name="rowFrom">The position of the new row</param>
         /// <param name="rows">Number of rows to insert.</param>
         /// <param name="copyStylesFromRow">Copy Styles from this row. Applied to all inserted rows</param>
-		public void InsertRow(int rowFrom, int rows, int copyStylesFromRow)
+        public void InsertRow(int rowFrom, int rows, int copyStylesFromRow)
         {
             CheckSheetType();
             var d = Dimension;
@@ -2762,7 +2762,7 @@ namespace OfficeOpenXml
         /// <param name="rows">Number of rows to delete</param>
         /// <param name="shiftOtherRowsUp">Not used. Rows are always shifted</param>
         public void DeleteRow(int rowFrom, int rows, bool shiftOtherRowsUp)
-		{
+        {
             DeleteRow(rowFrom, rows);
         }
 #endregion
@@ -4291,21 +4291,21 @@ namespace OfficeOpenXml
             }
         }
         /// <summary>
-		/// Returns the style ID given a style name.  
-		/// The style ID will be created if not found, but only if the style name exists!
-		/// </summary>
-		/// <param name="StyleName"></param>
-		/// <returns></returns>
-		internal int GetStyleID(string StyleName)
-		{
-			ExcelNamedStyleXml namedStyle=null;
+        /// Returns the style ID given a style name.  
+        /// The style ID will be created if not found, but only if the style name exists!
+        /// </summary>
+        /// <param name="StyleName"></param>
+        /// <returns></returns>
+        internal int GetStyleID(string StyleName)
+        {
+            ExcelNamedStyleXml namedStyle=null;
             Workbook.Styles.NamedStyles.FindByID(StyleName, ref namedStyle);
             if (namedStyle.XfId == int.MinValue)
             {
                 namedStyle.XfId=Workbook.Styles.CellXfs.FindIndexByID(namedStyle.Style.Id);
             }
             return namedStyle.XfId;
-		}
+        }
         /// <summary>
         /// The workbook object
         /// </summary>

--- a/EPPlus/ExcelWorksheetView.cs
+++ b/EPPlus/ExcelWorksheetView.cs
@@ -34,11 +34,11 @@ using System.Xml;
 
 namespace OfficeOpenXml
 {
-	/// <summary>
-	/// Represents the different view states of the worksheet
-	/// </summary>
-	public class ExcelWorksheetView : XmlHelper
-	{
+    /// <summary>
+    /// Represents the different view states of the worksheet
+    /// </summary>
+    public class ExcelWorksheetView : XmlHelper
+    {
         /// <summary>
         /// The worksheet panes after a freeze or split.
         /// </summary>
@@ -89,7 +89,7 @@ namespace OfficeOpenXml
 
             private void CreateSelectionElement()
             {
- 	            _selectionNode=TopNode.OwnerDocument.CreateElement("selection", ExcelPackage.schemaMain);
+                 _selectionNode=TopNode.OwnerDocument.CreateElement("selection", ExcelPackage.schemaMain);
                 TopNode.AppendChild(_selectionNode);
                 TopNode=_selectionNode;             
             }
@@ -126,24 +126,24 @@ namespace OfficeOpenXml
                 }
             }
         }
-		private ExcelWorksheet _worksheet;
+        private ExcelWorksheet _worksheet;
 
-		#region ExcelWorksheetView Constructor
-		/// <summary>
-		/// Creates a new ExcelWorksheetView which provides access to all the view states of the worksheet.
-		/// </summary>
+        #region ExcelWorksheetView Constructor
+        /// <summary>
+        /// Creates a new ExcelWorksheetView which provides access to all the view states of the worksheet.
+        /// </summary>
         /// <param name="ns"></param>
         /// <param name="node"></param>
         /// <param name="xlWorksheet"></param>
-		internal ExcelWorksheetView(XmlNamespaceManager ns, XmlNode node,  ExcelWorksheet xlWorksheet) :
+        internal ExcelWorksheetView(XmlNamespaceManager ns, XmlNode node,  ExcelWorksheet xlWorksheet) :
             base(ns, node)
-		{
+        {
             _worksheet = xlWorksheet;
             SchemaNodeOrder = new string[] { "sheetViews", "sheetView", "pane", "selection" };
             Panes = LoadPanes(); 
-		}
+        }
 
-		#endregion
+        #endregion
         private ExcelWorksheetPanes[] LoadPanes()
         {
             XmlNodeList nodes = TopNode.SelectNodes("//d:selection", NameSpaceManager);
@@ -162,19 +162,19 @@ namespace OfficeOpenXml
                 return panes;
             }
         }
-		#region SheetViewElement
-		/// <summary>
-		/// Returns a reference to the sheetView element
-		/// </summary>
-		protected internal XmlElement SheetViewElement
-		{
-			get 
-			{
-				return (XmlElement)TopNode;
-			}
-		}
-		#endregion
-		#region TabSelected
+        #region SheetViewElement
+        /// <summary>
+        /// Returns a reference to the sheetView element
+        /// </summary>
+        protected internal XmlElement SheetViewElement
+        {
+            get 
+            {
+                return (XmlElement)TopNode;
+            }
+        }
+        #endregion
+        #region TabSelected
         private XmlElement _selectionNode = null;
         private XmlElement SelectionNode
         {
@@ -327,23 +327,23 @@ namespace OfficeOpenXml
                 SetXmlNodeString("@tabSelected", "0");
         }
 
-		/// <summary>
-		/// Sets the view mode of the worksheet to pagelayout
-		/// </summary>
-		public bool PageLayoutView
-		{
-			get
-			{
+        /// <summary>
+        /// Sets the view mode of the worksheet to pagelayout
+        /// </summary>
+        public bool PageLayoutView
+        {
+            get
+            {
                 return GetXmlNodeString("@view") == "pageLayout";
-			}
-			set
-			{
+            }
+            set
+            {
                 if (value)
                     SetXmlNodeString("@view", "pageLayout");
                 else
                     SheetViewElement.RemoveAttribute("view");
-			}
-		}
+            }
+        }
         /// <summary>
         /// Sets the view mode of the worksheet to pagebreak
         /// </summary>

--- a/EPPlus/ExcelWorksheets.cs
+++ b/EPPlus/ExcelWorksheets.cs
@@ -50,27 +50,27 @@ using OfficeOpenXml.Table.PivotTable;
 
 namespace OfficeOpenXml
 {
-	/// <summary>
-	/// The collection of worksheets for the workbook
-	/// </summary>
-	public class ExcelWorksheets : XmlHelper, IEnumerable<ExcelWorksheet>, IDisposable
-	{
-		#region Private Properties
+    /// <summary>
+    /// The collection of worksheets for the workbook
+    /// </summary>
+    public class ExcelWorksheets : XmlHelper, IEnumerable<ExcelWorksheet>, IDisposable
+    {
+        #region Private Properties
         private ExcelPackage _pck;
         private Dictionary<int, ExcelWorksheet> _worksheets;
-		private XmlNamespaceManager _namespaceManager;
-		#endregion
-		#region ExcelWorksheets Constructor
-		internal ExcelWorksheets(ExcelPackage pck, XmlNamespaceManager nsm, XmlNode topNode) :
+        private XmlNamespaceManager _namespaceManager;
+        #endregion
+        #region ExcelWorksheets Constructor
+        internal ExcelWorksheets(ExcelPackage pck, XmlNamespaceManager nsm, XmlNode topNode) :
             base(nsm, topNode)
-		{
-			_pck = pck;
+        {
+            _pck = pck;
             _namespaceManager = nsm;
-			_worksheets = new Dictionary<int, ExcelWorksheet>();
-			int positionID = _pck._worksheetAdd;
+            _worksheets = new Dictionary<int, ExcelWorksheet>();
+            int positionID = _pck._worksheetAdd;
 
             foreach (XmlNode sheetNode in topNode.ChildNodes)
-			{
+            {
                 if (sheetNode.NodeType == XmlNodeType.Element)
                 {
                     string name = sheetNode.Attributes["name"].Value;
@@ -98,8 +98,8 @@ namespace OfficeOpenXml
                     }
                     positionID++;
                 }
-			}
-		}
+            }
+        }
 
         private eWorkSheetHidden TranslateHidden(string value)
         {
@@ -113,27 +113,27 @@ namespace OfficeOpenXml
                     return eWorkSheetHidden.Visible;
             }
         }
-		#endregion
-		#region ExcelWorksheets Public Properties
-		/// <summary>
-		/// Returns the number of worksheets in the workbook
-		/// </summary>
-		public int Count
-		{
-			get { return (_worksheets.Count); }
-		}
-		#endregion
+        #endregion
+        #region ExcelWorksheets Public Properties
+        /// <summary>
+        /// Returns the number of worksheets in the workbook
+        /// </summary>
+        public int Count
+        {
+            get { return (_worksheets.Count); }
+        }
+        #endregion
         private const string ERR_DUP_WORKSHEET = "A worksheet with this name already exists in the workbook";
         internal const string WORKSHEET_CONTENTTYPE = @"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
         internal const string CHARTSHEET_CONTENTTYPE = @"application/vnd.openxmlformats-officedocument.spreadsheetml.chartsheet+xml";
-		#region ExcelWorksheets Public Methods
-		/// <summary>
+        #region ExcelWorksheets Public Methods
+        /// <summary>
         /// Foreach support
-		/// </summary>
-		/// <returns>An enumerator</returns>
-		public IEnumerator<ExcelWorksheet> GetEnumerator()
-		{
-			return (_worksheets.Values.GetEnumerator());
+        /// </summary>
+        /// <returns>An enumerator</returns>
+        public IEnumerator<ExcelWorksheet> GetEnumerator()
+        {
+            return (_worksheets.Values.GetEnumerator());
         }
         #region IEnumerable Members
 
@@ -143,16 +143,16 @@ namespace OfficeOpenXml
         }
 
         #endregion
-		#region Add Worksheet
-		/// <summary>
-		/// Adds a new blank worksheet.
-		/// </summary>
-		/// <param name="Name">The name of the workbook</param>
-		public ExcelWorksheet Add(string Name)
-		{
+        #region Add Worksheet
+        /// <summary>
+        /// Adds a new blank worksheet.
+        /// </summary>
+        /// <param name="Name">The name of the workbook</param>
+        public ExcelWorksheet Add(string Name)
+        {
             ExcelWorksheet worksheet = AddSheet(Name,false, null);
-			return worksheet;
-		}
+            return worksheet;
+        }
         private ExcelWorksheet AddSheet(string Name, bool isChart, eChartType? chartType, ExcelPivotTable pivotTableSource = null)
         {
             int sheetID;
@@ -747,30 +747,30 @@ namespace OfficeOpenXml
         }
 
         private void CopyVmlDrawing(ExcelWorksheet origSheet, ExcelWorksheet newSheet)
-		{
-			var xml = origSheet.VmlDrawingsComments.VmlDrawingXml.OuterXml;
-			var vmlUri = new Uri(string.Format("/xl/drawings/vmlDrawing{0}.vml", newSheet.SheetID), UriKind.Relative);
-			var part = _pck.Package.CreatePart(vmlUri, "application/vnd.openxmlformats-officedocument.vmlDrawing", _pck.Compression);
-			using (var streamDrawing = new StreamWriter(part.GetStream(FileMode.Create, FileAccess.Write)))
-			{
-				streamDrawing.Write(xml);
+        {
+            var xml = origSheet.VmlDrawingsComments.VmlDrawingXml.OuterXml;
+            var vmlUri = new Uri(string.Format("/xl/drawings/vmlDrawing{0}.vml", newSheet.SheetID), UriKind.Relative);
+            var part = _pck.Package.CreatePart(vmlUri, "application/vnd.openxmlformats-officedocument.vmlDrawing", _pck.Compression);
+            using (var streamDrawing = new StreamWriter(part.GetStream(FileMode.Create, FileAccess.Write)))
+            {
+                streamDrawing.Write(xml);
                 streamDrawing.Flush();
             }
-			
+            
             //Add the relationship ID to the worksheet xml.
-			var vmlRelation = newSheet.Part.CreateRelationship(UriHelper.GetRelativeUri(newSheet.WorksheetUri,vmlUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/vmlDrawing");
-			var e = newSheet.WorksheetXml.SelectSingleNode("//d:legacyDrawing", _namespaceManager) as XmlElement;
-			if (e == null)
-			{
-				e = newSheet.WorksheetXml.CreateNode(XmlNodeType.Entity, "//d:legacyDrawing", _namespaceManager.LookupNamespace("d")) as XmlElement;
-			}
-			if (e != null)
-			{
-				e.SetAttribute("id", ExcelPackage.schemaRelationships, vmlRelation.Id);
-			}
-		}
+            var vmlRelation = newSheet.Part.CreateRelationship(UriHelper.GetRelativeUri(newSheet.WorksheetUri,vmlUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/vmlDrawing");
+            var e = newSheet.WorksheetXml.SelectSingleNode("//d:legacyDrawing", _namespaceManager) as XmlElement;
+            if (e == null)
+            {
+                e = newSheet.WorksheetXml.CreateNode(XmlNodeType.Entity, "//d:legacyDrawing", _namespaceManager.LookupNamespace("d")) as XmlElement;
+            }
+            if (e != null)
+            {
+                e.SetAttribute("id", ExcelPackage.schemaRelationships, vmlRelation.Id);
+            }
+        }
 
-		string CreateWorkbookRel(string Name, int sheetID, Uri uriWorksheet, bool isChart)
+        string CreateWorkbookRel(string Name, int sheetID, Uri uriWorksheet, bool isChart)
         {
             //Create the relationship between the workbook and the new worksheet
             var rel = _pck.Workbook.Part.CreateRelationship(UriHelper.GetRelativeUri(_pck.Workbook.WorkbookUri, uriWorksheet), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/" + (isChart ? "chartsheet" : "worksheet"));
@@ -843,13 +843,13 @@ namespace OfficeOpenXml
             return System.Text.RegularExpressions.Regex.IsMatch(Name, @":|\?|/|\\|\[|\]");
         }
 
-		/// <summary>
-		/// Creates the XML document representing a new empty worksheet
-		/// </summary>
-		/// <returns></returns>
-		internal XmlDocument CreateNewWorksheet(bool isChart)
-		{
-			XmlDocument xmlDoc = new XmlDocument();
+        /// <summary>
+        /// Creates the XML document representing a new empty worksheet
+        /// </summary>
+        /// <returns></returns>
+        internal XmlDocument CreateNewWorksheet(bool isChart)
+        {
+            XmlDocument xmlDoc = new XmlDocument();
             XmlElement elemWs = xmlDoc.CreateElement(isChart ? "chartsheet" : "worksheet", ExcelPackage.schemaMain);
             elemWs.SetAttribute("xmlns:r", ExcelPackage.schemaRelationships);
             xmlDoc.AppendChild(elemWs);
@@ -886,16 +886,16 @@ namespace OfficeOpenXml
                 elemWs.AppendChild(elemSheetData);
             }
             return xmlDoc;
-		}
-		#endregion
-		#region Delete Worksheet
-		/// <summary>
-		/// Deletes a worksheet from the collection
-		/// </summary>
-		/// <param name="Index">The position of the worksheet in the workbook</param>
-		public void Delete(int Index)
-		{
-			/*
+        }
+        #endregion
+        #region Delete Worksheet
+        /// <summary>
+        /// Deletes a worksheet from the collection
+        /// </summary>
+        /// <param name="Index">The position of the worksheet in the workbook</param>
+        public void Delete(int Index)
+        {
+            /*
             * Hack to prefetch all the drawings,
             * so that all the images are referenced, 
             * to prevent the deletion of the image file, 
@@ -918,29 +918,29 @@ namespace OfficeOpenXml
                 worksheet.Comments.Clear();
             }
                         
-		    //Delete any parts still with relations to the Worksheet.
+            //Delete any parts still with relations to the Worksheet.
             DeleteRelationsAndParts(worksheet.Part);
 
 
             //Delete the worksheet part and relation from the package 
-			_pck.Workbook.Part.DeleteRelationship(worksheet.RelationshipID);
+            _pck.Workbook.Part.DeleteRelationship(worksheet.RelationshipID);
 
             //Delete worksheet from the workbook XML
-			XmlNode sheetsNode = _pck.Workbook.WorkbookXml.SelectSingleNode("//d:workbook/d:sheets", _namespaceManager);
-			if (sheetsNode != null)
-			{
-				XmlNode sheetNode = sheetsNode.SelectSingleNode(string.Format("./d:sheet[@sheetId={0}]", worksheet.SheetID), _namespaceManager);
-				if (sheetNode != null)
-				{
-					sheetsNode.RemoveChild(sheetNode);
-				}
-			}
-			_worksheets.Remove(Index);
+            XmlNode sheetsNode = _pck.Workbook.WorkbookXml.SelectSingleNode("//d:workbook/d:sheets", _namespaceManager);
+            if (sheetsNode != null)
+            {
+                XmlNode sheetNode = sheetsNode.SelectSingleNode(string.Format("./d:sheet[@sheetId={0}]", worksheet.SheetID), _namespaceManager);
+                if (sheetNode != null)
+                {
+                    sheetsNode.RemoveChild(sheetNode);
+                }
+            }
+            _worksheets.Remove(Index);
             if (_pck.Workbook.VbaProject != null)
             {
                 _pck.Workbook.VbaProject.Modules.Remove(worksheet.CodeModule);
             }
-			ReindexWorksheetDictionary();
+            ReindexWorksheetDictionary();
             //If the active sheet is deleted, set the first tab as active.
             if (_pck.Workbook.View.ActiveTab >= _pck.Workbook.Worksheets.Count)
             {
@@ -968,25 +968,25 @@ namespace OfficeOpenXml
             _pck.Package.DeletePart(part.Uri);
         }
 
-		/// <summary>
-		/// Deletes a worksheet from the collection
-		/// </summary>
-		/// <param name="name">The name of the worksheet in the workbook</param>
-		public void Delete(string name)
-		{
-			var sheet = this[name];
-			if (sheet == null)
-			{
-				throw new ArgumentException(string.Format("Could not find worksheet to delete '{0}'", name));
-			}
-			Delete(sheet.PositionID);
-		}
-		/// <summary>
+        /// <summary>
+        /// Deletes a worksheet from the collection
+        /// </summary>
+        /// <param name="name">The name of the worksheet in the workbook</param>
+        public void Delete(string name)
+        {
+            var sheet = this[name];
+            if (sheet == null)
+            {
+                throw new ArgumentException(string.Format("Could not find worksheet to delete '{0}'", name));
+            }
+            Delete(sheet.PositionID);
+        }
+        /// <summary>
         /// Delete a worksheet from the collection
         /// </summary>
         /// <param name="Worksheet">The worksheet to delete</param>
         public void Delete(ExcelWorksheet Worksheet)
-		{
+        {
             if (Worksheet.PositionID <= _worksheets.Count && Worksheet == _worksheets[Worksheet.PositionID])
             {
                 Delete(Worksheet.PositionID);
@@ -997,17 +997,17 @@ namespace OfficeOpenXml
             }
         }
         #endregion
-		internal void ReindexWorksheetDictionary()
-		{
-			var index = _pck._worksheetAdd;
-			var worksheets = new Dictionary<int, ExcelWorksheet>();
-			foreach (var entry in _worksheets)
-			{
-				entry.Value.PositionID = index;
-				worksheets.Add(index++, entry.Value);
-			}
-			_worksheets = worksheets;
-		}
+        internal void ReindexWorksheetDictionary()
+        {
+            var index = _pck._worksheetAdd;
+            var worksheets = new Dictionary<int, ExcelWorksheet>();
+            foreach (var entry in _worksheets)
+            {
+                entry.Value.PositionID = index;
+                worksheets.Add(index++, entry.Value);
+            }
+            _worksheets = worksheets;
+        }
 
 #if Core
         /// <summary>
@@ -1025,40 +1025,40 @@ namespace OfficeOpenXml
         /// <returns></returns>
 #endif
         public ExcelWorksheet this[int PositionID]
-		{
-			get
-			{
-			    if (_worksheets.ContainsKey(PositionID))
-			    {
-			        return _worksheets[PositionID];
-			    }
-			    else
-			    {
-			        throw (new IndexOutOfRangeException("Worksheet position out of range."));
-			    }
-			}
-		}
+        {
+            get
+            {
+                if (_worksheets.ContainsKey(PositionID))
+                {
+                    return _worksheets[PositionID];
+                }
+                else
+                {
+                    throw (new IndexOutOfRangeException("Worksheet position out of range."));
+                }
+            }
+        }
 
-		/// <summary>
-		/// Returns the worksheet matching the specified name
-		/// </summary>
-		/// <param name="Name">The name of the worksheet</param>
-		/// <returns></returns>
-		public ExcelWorksheet this[string Name]
-		{
-			get
-			{
+        /// <summary>
+        /// Returns the worksheet matching the specified name
+        /// </summary>
+        /// <param name="Name">The name of the worksheet</param>
+        /// <returns></returns>
+        public ExcelWorksheet this[string Name]
+        {
+            get
+            {
                 return GetByName(Name);
-			}
-		}
-		/// <summary>
-		/// Copies the named worksheet and creates a new worksheet in the same workbook
-		/// </summary>
-		/// <param name="Name">The name of the existing worksheet</param>
-		/// <param name="NewName">The name of the new worksheet to create</param>
-		/// <returns>The new copy added to the end of the worksheets collection</returns>
-		public ExcelWorksheet Copy(string Name, string NewName)
-		{
+            }
+        }
+        /// <summary>
+        /// Copies the named worksheet and creates a new worksheet in the same workbook
+        /// </summary>
+        /// <param name="Name">The name of the existing worksheet</param>
+        /// <param name="NewName">The name of the new worksheet to create</param>
+        /// <returns>The new copy added to the end of the worksheets collection</returns>
+        public ExcelWorksheet Copy(string Name, string NewName)
+        {
             ExcelWorksheet Copy = this[Name];
             if (Copy == null)
                 throw new ArgumentException(string.Format("Copy worksheet error: Could not find worksheet to copy '{0}'", Name));
@@ -1090,112 +1090,112 @@ namespace OfficeOpenXml
             return (xlWorksheet);
         }
         #region MoveBefore and MoveAfter Methods
-		/// <summary>
-		/// Moves the source worksheet to the position before the target worksheet
-		/// </summary>
-		/// <param name="sourceName">The name of the source worksheet</param>
-		/// <param name="targetName">The name of the target worksheet</param>
-		public void MoveBefore(string sourceName, string targetName)
-		{
-			Move(sourceName, targetName, false);
-		}
+        /// <summary>
+        /// Moves the source worksheet to the position before the target worksheet
+        /// </summary>
+        /// <param name="sourceName">The name of the source worksheet</param>
+        /// <param name="targetName">The name of the target worksheet</param>
+        public void MoveBefore(string sourceName, string targetName)
+        {
+            Move(sourceName, targetName, false);
+        }
 
-		/// <summary>
-		/// Moves the source worksheet to the position before the target worksheet
-		/// </summary>
-		/// <param name="sourcePositionId">The id of the source worksheet</param>
-		/// <param name="targetPositionId">The id of the target worksheet</param>
-		public void MoveBefore(int sourcePositionId, int targetPositionId)
-		{
-			Move(sourcePositionId, targetPositionId, false);
-		}
+        /// <summary>
+        /// Moves the source worksheet to the position before the target worksheet
+        /// </summary>
+        /// <param name="sourcePositionId">The id of the source worksheet</param>
+        /// <param name="targetPositionId">The id of the target worksheet</param>
+        public void MoveBefore(int sourcePositionId, int targetPositionId)
+        {
+            Move(sourcePositionId, targetPositionId, false);
+        }
 
-		/// <summary>
-		/// Moves the source worksheet to the position after the target worksheet
-		/// </summary>
-		/// <param name="sourceName">The name of the source worksheet</param>
-		/// <param name="targetName">The name of the target worksheet</param>
-		public void MoveAfter(string sourceName, string targetName)
-		{
-			Move(sourceName, targetName, true);
-		}
+        /// <summary>
+        /// Moves the source worksheet to the position after the target worksheet
+        /// </summary>
+        /// <param name="sourceName">The name of the source worksheet</param>
+        /// <param name="targetName">The name of the target worksheet</param>
+        public void MoveAfter(string sourceName, string targetName)
+        {
+            Move(sourceName, targetName, true);
+        }
 
-		/// <summary>
-		/// Moves the source worksheet to the position after the target worksheet
-		/// </summary>
-		/// <param name="sourcePositionId">The id of the source worksheet</param>
-		/// <param name="targetPositionId">The id of the target worksheet</param>
-		public void MoveAfter(int sourcePositionId, int targetPositionId)
-		{
-			Move(sourcePositionId, targetPositionId, true);
-		}
+        /// <summary>
+        /// Moves the source worksheet to the position after the target worksheet
+        /// </summary>
+        /// <param name="sourcePositionId">The id of the source worksheet</param>
+        /// <param name="targetPositionId">The id of the target worksheet</param>
+        public void MoveAfter(int sourcePositionId, int targetPositionId)
+        {
+            Move(sourcePositionId, targetPositionId, true);
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="sourceName"></param>
-		public void MoveToStart(string sourceName)
-		{
-			var sourceSheet = this[sourceName];
-			if (sourceSheet == null)
-			{
-				throw new Exception(string.Format("Move worksheet error: Could not find worksheet to move '{0}'", sourceName));
-			}
-			Move(sourceSheet.PositionID, _pck._worksheetAdd, false);
-		}
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sourceName"></param>
+        public void MoveToStart(string sourceName)
+        {
+            var sourceSheet = this[sourceName];
+            if (sourceSheet == null)
+            {
+                throw new Exception(string.Format("Move worksheet error: Could not find worksheet to move '{0}'", sourceName));
+            }
+            Move(sourceSheet.PositionID, _pck._worksheetAdd, false);
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="sourcePositionId"></param>
-		public void MoveToStart(int sourcePositionId)
-		{
-			Move(sourcePositionId, _pck._worksheetAdd, false);
-		}
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sourcePositionId"></param>
+        public void MoveToStart(int sourcePositionId)
+        {
+            Move(sourcePositionId, _pck._worksheetAdd, false);
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="sourceName"></param>
-		public void MoveToEnd(string sourceName)
-		{
-			var sourceSheet = this[sourceName];
-			if (sourceSheet == null)
-			{
-				throw new Exception(string.Format("Move worksheet error: Could not find worksheet to move '{0}'", sourceName));
-			}
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sourceName"></param>
+        public void MoveToEnd(string sourceName)
+        {
+            var sourceSheet = this[sourceName];
+            if (sourceSheet == null)
+            {
+                throw new Exception(string.Format("Move worksheet error: Could not find worksheet to move '{0}'", sourceName));
+            }
             Move(sourceSheet.PositionID, _worksheets.Count + (_pck._worksheetAdd - 1), true);
-		}
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="sourcePositionId"></param>
-		public void MoveToEnd(int sourcePositionId)
-		{
-			Move(sourcePositionId, _worksheets.Count+(_pck._worksheetAdd - 1), true);
-		}
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sourcePositionId"></param>
+        public void MoveToEnd(int sourcePositionId)
+        {
+            Move(sourcePositionId, _worksheets.Count+(_pck._worksheetAdd - 1), true);
+        }
 
-		private void Move(string sourceName, string targetName, bool placeAfter)
-		{
-			var sourceSheet = this[sourceName];
-			if (sourceSheet == null)
-			{
-				throw new Exception(string.Format("Move worksheet error: Could not find worksheet to move '{0}'", sourceName));
-			}
-			var targetSheet = this[targetName];
-			if (targetSheet == null)
-			{
-				throw new Exception(string.Format("Move worksheet error: Could not find worksheet to move '{0}'", targetName));
-			}
-			Move(sourceSheet.PositionID, targetSheet.PositionID, placeAfter);
-		}
+        private void Move(string sourceName, string targetName, bool placeAfter)
+        {
+            var sourceSheet = this[sourceName];
+            if (sourceSheet == null)
+            {
+                throw new Exception(string.Format("Move worksheet error: Could not find worksheet to move '{0}'", sourceName));
+            }
+            var targetSheet = this[targetName];
+            if (targetSheet == null)
+            {
+                throw new Exception(string.Format("Move worksheet error: Could not find worksheet to move '{0}'", targetName));
+            }
+            Move(sourceSheet.PositionID, targetSheet.PositionID, placeAfter);
+        }
 
-		private void Move(int sourcePositionId, int targetPositionId, bool placeAfter)
-		{
+        private void Move(int sourcePositionId, int targetPositionId, bool placeAfter)
+        {
             // Bugfix: if source and target are the same worksheet the following code will create a duplicate
             //         which will cause a corrupt workbook. /swmal 2014-05-10
-		    if (sourcePositionId == targetPositionId) return;
+            if (sourcePositionId == targetPositionId) return;
 
             lock (_worksheets)
             {
@@ -1249,10 +1249,10 @@ namespace OfficeOpenXml
 
                 MoveSheetXmlNode(sourceSheet, targetSheet, placeAfter);
             }
-		}
+        }
 
-		private void MoveSheetXmlNode(ExcelWorksheet sourceSheet, ExcelWorksheet targetSheet, bool placeAfter)
-		{
+        private void MoveSheetXmlNode(ExcelWorksheet sourceSheet, ExcelWorksheet targetSheet, bool placeAfter)
+        {
             lock (TopNode.OwnerDocument)
             {
                 var sourceNode = TopNode.SelectSingleNode(string.Format("d:sheet[@sheetId = '{0}']", sourceSheet.SheetID), _namespaceManager);
@@ -1270,20 +1270,20 @@ namespace OfficeOpenXml
                     TopNode.InsertBefore(sourceNode, targetNode);
                 }
             }
-		}
+        }
 
 #endregion
         public void Dispose()
         {    
-		if (_worksheets != null)
-	     	{
-		     foreach (var sheet in this._worksheets.Values) 
-		     { 
-			 ((IDisposable)sheet).Dispose(); 
-		     } 
-		     _worksheets = null;
-		     _pck = null;
-		}
+        if (_worksheets != null)
+             {
+             foreach (var sheet in this._worksheets.Values) 
+             { 
+             ((IDisposable)sheet).Dispose(); 
+             } 
+             _worksheets = null;
+             _pck = null;
+        }
         }
     } // end class Worksheets
 }

--- a/EPPlus/FormulaParsing/Excel/Functions/Math/Average.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/Math/Average.cs
@@ -72,15 +72,15 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Math
             else
             {
                 var numericValue = GetNumericValue(arg.Value, isInArray);
-				if (numericValue.HasValue)
-				{
-					nValues++;
-					retVal += numericValue.Value;
-				}
-				else if (arg.Value is string && !isInArray)
-				{
-					ThrowExcelErrorValueException(eErrorType.Value);
-				}
+                if (numericValue.HasValue)
+                {
+                    nValues++;
+                    retVal += numericValue.Value;
+                }
+                else if (arg.Value is string && !isInArray)
+                {
+                    ThrowExcelErrorValueException(eErrorType.Value);
+                }
             }
             CheckForAndHandleExcelError(arg);
         }
@@ -91,23 +91,23 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Math
             {
                 return ConvertUtil.GetValueDouble(obj);
             }
-			if (!isInArray)
-			{
-				double number;
-				System.DateTime date;
-				if (obj is bool)
-				{
-					return ConvertUtil.GetValueDouble(obj);
-				}
-				else if (ConvertUtil.TryParseNumericString(obj, out number))
-				{
-					return number;
-				}
-				else if (ConvertUtil.TryParseDateString(obj, out date))
-				{
-					return date.ToOADate();
-				}
-			}
+            if (!isInArray)
+            {
+                double number;
+                System.DateTime date;
+                if (obj is bool)
+                {
+                    return ConvertUtil.GetValueDouble(obj);
+                }
+                else if (ConvertUtil.TryParseNumericString(obj, out number))
+                {
+                    return number;
+                }
+                else if (ConvertUtil.TryParseDateString(obj, out date))
+                {
+                    return date.ToOADate();
+                }
+            }
             return default(double?);
         }
     }

--- a/EPPlus/FormulaParsing/Excel/Functions/Math/AverageA.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/Math/AverageA.cs
@@ -64,21 +64,21 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Math
                 {
                     if (ShouldIgnore(c, context)) continue;
                     CheckForAndHandleExcelError(c);
-					if (IsNumeric(c.Value) && !(c.Value is bool))
-					{
-						nValues++;
-						retVal += c.ValueDouble;
-					}
-					else if (c.Value is bool)
-					{
-						nValues++;
-						retVal += (bool)c.Value ? 1 : 0;
-					}
-					else if (c.Value is string)
-					{
-						nValues++;
-					}
-				}
+                    if (IsNumeric(c.Value) && !(c.Value is bool))
+                    {
+                        nValues++;
+                        retVal += c.ValueDouble;
+                    }
+                    else if (c.Value is bool)
+                    {
+                        nValues++;
+                        retVal += (bool)c.Value ? 1 : 0;
+                    }
+                    else if (c.Value is string)
+                    {
+                        nValues++;
+                    }
+                }
             }
             else
             {
@@ -105,29 +105,29 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Math
 
         private double? GetNumericValue(object obj, bool isInArray)
         {
-			double number;
-			System.DateTime date;
+            double number;
+            System.DateTime date;
             if (IsNumeric(obj) && !(obj is bool))
             {
                 return ConvertUtil.GetValueDouble(obj);
             }
-			if (!isInArray)
-			{
-				if (obj is bool)
-				{
-					if (isInArray) return default(double?);
-					return ConvertUtil.GetValueDouble(obj);
-				}
-				else if (ConvertUtil.TryParseNumericString(obj, out number))
-				{
-					return number;
-				}
-				else if (ConvertUtil.TryParseDateString(obj, out date))
-				{
-					return date.ToOADate();
-				}
-			}
-			return default(double?);
+            if (!isInArray)
+            {
+                if (obj is bool)
+                {
+                    if (isInArray) return default(double?);
+                    return ConvertUtil.GetValueDouble(obj);
+                }
+                else if (ConvertUtil.TryParseNumericString(obj, out number))
+                {
+                    return number;
+                }
+                else if (ConvertUtil.TryParseDateString(obj, out date))
+                {
+                    return date.ToOADate();
+                }
+            }
+            return default(double?);
         }
     }
 }

--- a/EPPlus/FormulaParsing/Excel/Operators/Operator.cs
+++ b/EPPlus/FormulaParsing/Excel/Operators/Operator.cs
@@ -208,7 +208,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                         l = l ?? new CompileResult(0, DataType.Integer);
                         r = r ?? new CompileResult(0, DataType.Integer);
                         if ((l.IsNumeric || l.IsNumericString || l.IsDateString || l.Result is ExcelDataProvider.IRangeInfo) &&
-							(r.IsNumeric || r.IsNumericString || r.IsDateString || r.Result is ExcelDataProvider.IRangeInfo))
+                            (r.IsNumeric || r.IsNumericString || r.IsDateString || r.Result is ExcelDataProvider.IRangeInfo))
                         {
                             return new CompileResult(Math.Pow(l.ResultNumeric, r.ResultNumeric), DataType.Decimal);
                         }
@@ -317,7 +317,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Operators
                                 return new CompileResult(l.ResultNumeric * r.ResultNumeric, DataType.Integer);
                             }
                             else if ((l.IsNumeric || l.IsNumericString || l.IsDateString || l.Result is ExcelDataProvider.IRangeInfo) &&
-								(r.IsNumeric || r.IsNumericString || r.IsDateString || r.Result is ExcelDataProvider.IRangeInfo))
+                                (r.IsNumeric || r.IsNumericString || r.IsDateString || r.Result is ExcelDataProvider.IRangeInfo))
                             {
                                 return new CompileResult(l.ResultNumeric * r.ResultNumeric, DataType.Decimal);
                             }

--- a/EPPlus/FormulaParsing/ExcelUtilities/FormulaDependency.cs
+++ b/EPPlus/FormulaParsing/ExcelUtilities/FormulaDependency.cs
@@ -39,10 +39,10 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
     public class FormulaDependency
     {
         public FormulaDependency(ParsingScope scope)
-	    {   
+        {   
             ScopeId = scope.ScopeId;
             Address = scope.Address;
-	    }
+        }
         public Guid ScopeId { get; private set; }
 
         public RangeAddress Address { get; private set; }

--- a/EPPlus/FormulaParsing/Exceptions/ExcelErrorCodes.cs
+++ b/EPPlus/FormulaParsing/Exceptions/ExcelErrorCodes.cs
@@ -59,7 +59,7 @@ namespace OfficeOpenXml.FormulaParsing.Exceptions
             {
                 return ((ExcelErrorCodes)obj).Code.Equals(Code);
             }
- 	        return false;
+             return false;
         }
 
         public static bool operator == (ExcelErrorCodes c1, ExcelErrorCodes c2)

--- a/EPPlus/FormulaParsing/ExpressionGraph/CompileResult.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/CompileResult.cs
@@ -48,7 +48,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
             get { return _empty; }
         }
 
-		private double? _ResultNumeric;
+        private double? _ResultNumeric;
 
         public CompileResult(object result, DataType dataType)
         {
@@ -102,41 +102,41 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
         {
             get
             {
-				// We assume that Result does not change unless it is a range.
-				if (_ResultNumeric == null)
-				{
-					if (IsNumeric)
-					{
-						_ResultNumeric = Result == null ? 0 : Convert.ToDouble(Result);
-					}
-					else if (Result is DateTime)
-					{
-						_ResultNumeric = ((DateTime)Result).ToOADate();
-					}
-					else if (Result is TimeSpan)
-					{
-						_ResultNumeric = DateTime.FromOADate(0).Add((TimeSpan)Result).ToOADate();
-					}
-					else if (Result is ExcelDataProvider.IRangeInfo)
-					{
-						var c = ((ExcelDataProvider.IRangeInfo)Result).FirstOrDefault();
-						if (c == null)
-						{
-							return 0;
-						}
-						else
-						{
-							return c.ValueDoubleLogical;
-						}
-					}
-					// The IsNumericString and IsDateString properties will set _ResultNumeric for efficiency so we just need
-					// to check them here.
-					else if (!IsNumericString && !IsDateString)
-					{
-						_ResultNumeric = 0;
-					}
-				}
-				return _ResultNumeric.Value;
+                // We assume that Result does not change unless it is a range.
+                if (_ResultNumeric == null)
+                {
+                    if (IsNumeric)
+                    {
+                        _ResultNumeric = Result == null ? 0 : Convert.ToDouble(Result);
+                    }
+                    else if (Result is DateTime)
+                    {
+                        _ResultNumeric = ((DateTime)Result).ToOADate();
+                    }
+                    else if (Result is TimeSpan)
+                    {
+                        _ResultNumeric = DateTime.FromOADate(0).Add((TimeSpan)Result).ToOADate();
+                    }
+                    else if (Result is ExcelDataProvider.IRangeInfo)
+                    {
+                        var c = ((ExcelDataProvider.IRangeInfo)Result).FirstOrDefault();
+                        if (c == null)
+                        {
+                            return 0;
+                        }
+                        else
+                        {
+                            return c.ValueDoubleLogical;
+                        }
+                    }
+                    // The IsNumericString and IsDateString properties will set _ResultNumeric for efficiency so we just need
+                    // to check them here.
+                    else if (!IsNumericString && !IsDateString)
+                    {
+                        _ResultNumeric = 0;
+                    }
+                }
+                return _ResultNumeric.Value;
             }
         }
 
@@ -158,31 +158,31 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
         {
             get
             {
-				double result;
-				if (DataType == DataType.String && ConvertUtil.TryParseNumericString(Result, out result))
-				{
-					_ResultNumeric = result;
-					return true;
-				}
-				return false;
+                double result;
+                if (DataType == DataType.String && ConvertUtil.TryParseNumericString(Result, out result))
+                {
+                    _ResultNumeric = result;
+                    return true;
+                }
+                return false;
             }
         }
 
-		public bool IsDateString
-		{
-			get
-			{
-				DateTime result;
-				if (DataType == DataType.String && ConvertUtil.TryParseDateString(Result, out result))
-				{
-					_ResultNumeric = result.ToOADate();
-					return true;
-				}
-				return false;
-			}
-		}
+        public bool IsDateString
+        {
+            get
+            {
+                DateTime result;
+                if (DataType == DataType.String && ConvertUtil.TryParseDateString(Result, out result))
+                {
+                    _ResultNumeric = result.ToOADate();
+                    return true;
+                }
+                return false;
+            }
+        }
 
-		public bool IsResultOfSubtotal { get; set; }
+        public bool IsResultOfSubtotal { get; set; }
 
         public bool IsHiddenCell { get; set; }
     }

--- a/EPPlus/OfficeProperties.cs
+++ b/EPPlus/OfficeProperties.cs
@@ -203,22 +203,22 @@ namespace OfficeOpenXml
         const string CreatedPath = "dcterms:created";
 
         /// <summary>
-	    /// Gets/sets the created property of the document (core property)
-	    /// </summary>
-	    public DateTime Created
-	    {
-	        get
-	        {
-	            DateTime date;
-	            return DateTime.TryParse(_coreHelper.GetXmlNodeString(CreatedPath), out date) ? date : DateTime.MinValue;
-	        }
-	        set
-	        {
-	            var dateString = value.ToUniversalTime().ToString("s", CultureInfo.InvariantCulture) + "Z";
-	            _coreHelper.SetXmlNodeString(CreatedPath, dateString);
+        /// Gets/sets the created property of the document (core property)
+        /// </summary>
+        public DateTime Created
+        {
+            get
+            {
+                DateTime date;
+                return DateTime.TryParse(_coreHelper.GetXmlNodeString(CreatedPath), out date) ? date : DateTime.MinValue;
+            }
+            set
+            {
+                var dateString = value.ToUniversalTime().ToString("s", CultureInfo.InvariantCulture) + "Z";
+                _coreHelper.SetXmlNodeString(CreatedPath, dateString);
                 _coreHelper.SetXmlNodeString(CreatedPath + "/@xsi:type", "dcterms:W3CDTF");
-	        }
-	    }
+            }
+        }
 
         const string CategoryPath = "cp:category";
         /// <summary>
@@ -315,23 +315,23 @@ namespace OfficeOpenXml
         }
 
         const string ModifiedPath = "dcterms:modified";
-	    /// <summary>
-	    /// Gets/sets the modified property of the document (core property)
-	    /// </summary>
-	    public DateTime Modified
-	    {
-	        get
-	        {
-	            DateTime date;
-	            return DateTime.TryParse(_coreHelper.GetXmlNodeString(ModifiedPath), out date) ? date : DateTime.MinValue;
-	        }
-	        set
-	        {
-	            var dateString = value.ToUniversalTime().ToString("s", CultureInfo.InvariantCulture) + "Z";
-	            _coreHelper.SetXmlNodeString(ModifiedPath, dateString);
+        /// <summary>
+        /// Gets/sets the modified property of the document (core property)
+        /// </summary>
+        public DateTime Modified
+        {
+            get
+            {
+                DateTime date;
+                return DateTime.TryParse(_coreHelper.GetXmlNodeString(ModifiedPath), out date) ? date : DateTime.MinValue;
+            }
+            set
+            {
+                var dateString = value.ToUniversalTime().ToString("s", CultureInfo.InvariantCulture) + "Z";
+                _coreHelper.SetXmlNodeString(ModifiedPath, dateString);
                 _coreHelper.SetXmlNodeString(ModifiedPath + "/@xsi:type", "dcterms:W3CDTF");
-	        }
-	    }
+            }
+        }
         const string LinksUpToDatePath = "xp:Properties/xp:LinksUpToDate";
         /// <summary>
         /// Indicates whether hyperlinks in a document are up-to-date

--- a/EPPlus/Packaging/DotNetZip/ZipEntry.Read.cs
+++ b/EPPlus/Packaging/DotNetZip/ZipEntry.Read.cs
@@ -790,11 +790,11 @@ namespace OfficeOpenXml.Packaging.Ionic.Zip
                 _timestamp |= ZipEntryTimestamp.Windows;
                 _emitNtfsTimes = true;
             }
-   	    else
-	    {
+           else
+        {
                 // An unknown NTFS tag so simply skip it.
                 j += dataSize;				
-  	    }
+          }
             return j;
         }
 

--- a/EPPlus/RangeCollection.cs
+++ b/EPPlus/RangeCollection.cs
@@ -69,10 +69,10 @@ using OfficeOpenXml.Drawing.Vml;namespace OfficeOpenXml
                 RangeID = cellId;
             }
             internal IndexItem(ulong cellId, int listPointer)
-	        {
+            {
                 RangeID = cellId;
                 ListPointer=listPointer;
-	        }
+            }
             internal ulong RangeID;
             internal int ListPointer;
         }

--- a/EPPlus/Style/Dxf/ExcelDxfStyle.cs
+++ b/EPPlus/Style/Dxf/ExcelDxfStyle.cs
@@ -130,7 +130,7 @@ namespace OfficeOpenXml.Style.Dxf
         }
         protected internal override ExcelDxfStyleConditionalFormatting Clone()
         {
- 	       var s=new ExcelDxfStyleConditionalFormatting(_helper.NameSpaceManager, null, _styles);
+            var s=new ExcelDxfStyleConditionalFormatting(_helper.NameSpaceManager, null, _styles);
            s.Font = Font.Clone();
            s.NumberFormat = NumberFormat.Clone();
            s.Fill = Fill.Clone();

--- a/EPPlus/Style/ExcelBorder.cs
+++ b/EPPlus/Style/ExcelBorder.cs
@@ -43,7 +43,7 @@ namespace OfficeOpenXml.Style
     {
         internal Border(ExcelStyles styles, OfficeOpenXml.XmlHelper.ChangedEventHandler ChangedEvent, int PositionID, string address, int index) :
             base(styles, ChangedEvent, PositionID, address)
-	    {
+        {
             Index = index;
         }
         /// <summary>

--- a/EPPlus/Style/ExcelBorderItem.cs
+++ b/EPPlus/Style/ExcelBorderItem.cs
@@ -45,10 +45,10 @@ namespace OfficeOpenXml.Style
         StyleBase _parent;
         internal ExcelBorderItem (ExcelStyles styles, OfficeOpenXml.XmlHelper.ChangedEventHandler ChangedEvent, int worksheetID, string address, eStyleClass cls, StyleBase parent) : 
             base(styles, ChangedEvent, worksheetID, address)
-	    {
+        {
             _cls=cls;
             _parent = parent;
-	    }
+        }
         /// <summary>
         /// The line style of the border
         /// </summary>

--- a/EPPlus/Style/ExcelRichText.cs
+++ b/EPPlus/Style/ExcelRichText.cs
@@ -242,13 +242,13 @@ namespace OfficeOpenXml.Style
                 _collection.ConvertRichtext();
                 if (value == ExcelVerticalAlignmentFont.None)
                 {
-					// If Excel 2010 encounters a vertical align value of blank, it will not load
-					// the spreadsheet. So if None is specified, delete the node, it will be 
-					// recreated if a new value is applied later.
-					DeleteNode(VERT_ALIGN_PATH);
-				} else {
-					SetXmlNodeString(VERT_ALIGN_PATH, value.ToString().ToLowerInvariant());
-				}
+                    // If Excel 2010 encounters a vertical align value of blank, it will not load
+                    // the spreadsheet. So if None is specified, delete the node, it will be 
+                    // recreated if a new value is applied later.
+                    DeleteNode(VERT_ALIGN_PATH);
+                } else {
+                    SetXmlNodeString(VERT_ALIGN_PATH, value.ToString().ToLowerInvariant());
+                }
                 if (_callback != null) _callback();
             }
         }

--- a/EPPlus/Style/ExcelRichTextHtmlUtility.cs
+++ b/EPPlus/Style/ExcelRichTextHtmlUtility.cs
@@ -35,160 +35,160 @@ using System.Text.RegularExpressions;
 
 namespace OfficeOpenXml.Style
 {
-	public class ExcelRichTextHtmlUtility
-	{
+    public class ExcelRichTextHtmlUtility
+    {
 
-		/// <summary>
-		/// Provides basic HTML support by converting well-behaved HTML into appropriate RichText blocks.
-		/// HTML support is limited, and does not include font colors, sizes, or typefaces at this time,
-		/// and also does not support CSS style attributes. It does support line breaks using the BR tag.
-		///
-		/// This routine parses the HTML into RegEx pairings of an HTML tag and the text until the NEXT 
-		/// tag (if any). The tag is parsed to determine the setting change to be applied to the last set
-		/// of settings, and if the text is not blank, a new block is added to rich text.
-		/// </summary>
-		/// <param name="range"></param>
-		/// <param name="html">The HTML to parse into RichText</param>
-		/// <param name="defaultFontName"></param>
-		/// <param name="defaultFontSize"></param>
+        /// <summary>
+        /// Provides basic HTML support by converting well-behaved HTML into appropriate RichText blocks.
+        /// HTML support is limited, and does not include font colors, sizes, or typefaces at this time,
+        /// and also does not support CSS style attributes. It does support line breaks using the BR tag.
+        ///
+        /// This routine parses the HTML into RegEx pairings of an HTML tag and the text until the NEXT 
+        /// tag (if any). The tag is parsed to determine the setting change to be applied to the last set
+        /// of settings, and if the text is not blank, a new block is added to rich text.
+        /// </summary>
+        /// <param name="range"></param>
+        /// <param name="html">The HTML to parse into RichText</param>
+        /// <param name="defaultFontName"></param>
+        /// <param name="defaultFontSize"></param>
 
-		public static void SetRichTextFromHtml(ExcelRange range, string html, string defaultFontName, short defaultFontSize)
-		{
-			// Reset the cell value, just in case there is an existing RichText value.
-			range.Value = "";
+        public static void SetRichTextFromHtml(ExcelRange range, string html, string defaultFontName, short defaultFontSize)
+        {
+            // Reset the cell value, just in case there is an existing RichText value.
+            range.Value = "";
 
-			// Sanity check for blank values, skips creating Regex objects for performance.
-			if (String.IsNullOrEmpty(html))
-			{
-				range.IsRichText = false;
-				return;
-			}
+            // Sanity check for blank values, skips creating Regex objects for performance.
+            if (String.IsNullOrEmpty(html))
+            {
+                range.IsRichText = false;
+                return;
+            }
 
-			// Change all BR tags to line breaks. http://epplus.codeplex.com/discussions/238692/
-			// Cells with line breaks aren't necessarily considered rich text, so this is performed
-			// before parsing the HTML tags.
-			html = System.Text.RegularExpressions.Regex.Replace(html, @"<br[^>]*>", "\r\n", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            // Change all BR tags to line breaks. http://epplus.codeplex.com/discussions/238692/
+            // Cells with line breaks aren't necessarily considered rich text, so this is performed
+            // before parsing the HTML tags.
+            html = System.Text.RegularExpressions.Regex.Replace(html, @"<br[^>]*>", "\r\n", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-			string tag;
-			string text;
-			ExcelRichText thisrt = null;
-			bool isFirst = true;
+            string tag;
+            string text;
+            ExcelRichText thisrt = null;
+            bool isFirst = true;
 
-			// Get all pairs of legitimate tags and the text between them. This loop will
-			// only execute if there is at least one start or end tag.
-			foreach (Match m in System.Text.RegularExpressions.Regex.Matches(html, @"<(/?[a-z]+)[^<>]*>([\s\S]*?)(?=</?[a-z]+[^<>]*>|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase))
-			{
-				if (isFirst)
-				{
-					// On the very first match, set up the initial rich text object with
-					// the defaults for the text BEFORE the match.
-					range.IsRichText = true;
-					thisrt = range.RichText.Add(CleanText(html.Substring(0, m.Index)));	// May be 0-length
-					thisrt.Size = defaultFontSize;										// Set the default font size
-					thisrt.FontName = defaultFontName;									// Set the default font name
-					isFirst = false;
-				}
-				// Get the tag and the block of text until the NEXT tag or EOS. If there are HTML entities
-				// encoded, unencode them, they should be passed to RichText as normal characters (other
-				// than non-breaking spaces, which should be replaced with normal spaces, they break Excel.
-				tag = m.Groups[1].Captures[0].Value;
-				text = CleanText(m.Groups[2].Captures[0].Value);
+            // Get all pairs of legitimate tags and the text between them. This loop will
+            // only execute if there is at least one start or end tag.
+            foreach (Match m in System.Text.RegularExpressions.Regex.Matches(html, @"<(/?[a-z]+)[^<>]*>([\s\S]*?)(?=</?[a-z]+[^<>]*>|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase))
+            {
+                if (isFirst)
+                {
+                    // On the very first match, set up the initial rich text object with
+                    // the defaults for the text BEFORE the match.
+                    range.IsRichText = true;
+                    thisrt = range.RichText.Add(CleanText(html.Substring(0, m.Index)));	// May be 0-length
+                    thisrt.Size = defaultFontSize;										// Set the default font size
+                    thisrt.FontName = defaultFontName;									// Set the default font name
+                    isFirst = false;
+                }
+                // Get the tag and the block of text until the NEXT tag or EOS. If there are HTML entities
+                // encoded, unencode them, they should be passed to RichText as normal characters (other
+                // than non-breaking spaces, which should be replaced with normal spaces, they break Excel.
+                tag = m.Groups[1].Captures[0].Value;
+                text = CleanText(m.Groups[2].Captures[0].Value);
 
-				if (thisrt.Text == "")
-				{
-					// The most recent rich text block wasn't *actually* used last time around, so update
-					// the text and keep it as the "current" block. This happens with the first block if
-					// it starts with a tag, and may happen later if tags come one right after the other.
-					thisrt.Text = text;
-				}
-				else
-				{
-					// The current rich text block has some text, so create a new one. RichText.Add()
-					// automatically applies the settings from the previous block, other than vertical
-					// alignment.
-					thisrt = range.RichText.Add(text);
-				}
-				// Override the settings based on the current tag, keep all other settings.
-				SetStyleFromTag(tag, thisrt);
-			}
+                if (thisrt.Text == "")
+                {
+                    // The most recent rich text block wasn't *actually* used last time around, so update
+                    // the text and keep it as the "current" block. This happens with the first block if
+                    // it starts with a tag, and may happen later if tags come one right after the other.
+                    thisrt.Text = text;
+                }
+                else
+                {
+                    // The current rich text block has some text, so create a new one. RichText.Add()
+                    // automatically applies the settings from the previous block, other than vertical
+                    // alignment.
+                    thisrt = range.RichText.Add(text);
+                }
+                // Override the settings based on the current tag, keep all other settings.
+                SetStyleFromTag(tag, thisrt);
+            }
 
-			if (thisrt == null)
-			{
-				// No HTML tags were found, so treat this as a normal text value.
-				range.IsRichText = false;
-				range.Value = CleanText(html);
-			}
-			else if (String.IsNullOrEmpty(thisrt.Text))
-			{
-				// Rich text was found, but the last node contains no text, so remove it. This can happen if,
-				// say, the end of the string is an end tag or unsupported tag (common).
-				range.RichText.Remove(thisrt);
+            if (thisrt == null)
+            {
+                // No HTML tags were found, so treat this as a normal text value.
+                range.IsRichText = false;
+                range.Value = CleanText(html);
+            }
+            else if (String.IsNullOrEmpty(thisrt.Text))
+            {
+                // Rich text was found, but the last node contains no text, so remove it. This can happen if,
+                // say, the end of the string is an end tag or unsupported tag (common).
+                range.RichText.Remove(thisrt);
 
-				// Failsafe -- the HTML may be just tags, no text, in which case there may be no rich text
-				// directives that remain. If that is the case, turn off rich text and treat this like a blank
-				// cell value.
-				if (range.RichText.Count == 0)
-				{
-					range.IsRichText = false;
-					range.Value = "";
-				}
+                // Failsafe -- the HTML may be just tags, no text, in which case there may be no rich text
+                // directives that remain. If that is the case, turn off rich text and treat this like a blank
+                // cell value.
+                if (range.RichText.Count == 0)
+                {
+                    range.IsRichText = false;
+                    range.Value = "";
+                }
 
-			}
+            }
 
-		}
+        }
 
-		private static void SetStyleFromTag(string tag, ExcelRichText settings)
-		{
-			switch (tag.ToLower())
-			{
-				case "b":
-				case "strong":
-					settings.Bold = true;
-					break;
-				case "i":
-				case "em":
-					settings.Italic = true;
-					break;
-				case "u":
-					settings.UnderLine = true;
-					break;
-				case "s":
-				case "strike":
-					settings.Strike = true;
-					break;
-				case "sup":
-					settings.VerticalAlign = ExcelVerticalAlignmentFont.Superscript;
-					break;
-				case "sub":
-					settings.VerticalAlign = ExcelVerticalAlignmentFont.Subscript;
-					break;
-				case "/b":
-				case "/strong":
-					settings.Bold = false;
-					break;
-				case "/i":
-				case "/em":
-					settings.Italic = false;
-					break;
-				case "/u":
-					settings.UnderLine = false;
-					break;
-				case "/s":
-				case "/strike":
-					settings.Strike = false;
-					break;
-				case "/sup":
-				case "/sub":
-					settings.VerticalAlign = ExcelVerticalAlignmentFont.None;
-					break;
-				default:
-					// unsupported HTML, no style change
-					break;
-			}
-		}
+        private static void SetStyleFromTag(string tag, ExcelRichText settings)
+        {
+            switch (tag.ToLower())
+            {
+                case "b":
+                case "strong":
+                    settings.Bold = true;
+                    break;
+                case "i":
+                case "em":
+                    settings.Italic = true;
+                    break;
+                case "u":
+                    settings.UnderLine = true;
+                    break;
+                case "s":
+                case "strike":
+                    settings.Strike = true;
+                    break;
+                case "sup":
+                    settings.VerticalAlign = ExcelVerticalAlignmentFont.Superscript;
+                    break;
+                case "sub":
+                    settings.VerticalAlign = ExcelVerticalAlignmentFont.Subscript;
+                    break;
+                case "/b":
+                case "/strong":
+                    settings.Bold = false;
+                    break;
+                case "/i":
+                case "/em":
+                    settings.Italic = false;
+                    break;
+                case "/u":
+                    settings.UnderLine = false;
+                    break;
+                case "/s":
+                case "/strike":
+                    settings.Strike = false;
+                    break;
+                case "/sup":
+                case "/sub":
+                    settings.VerticalAlign = ExcelVerticalAlignmentFont.None;
+                    break;
+                default:
+                    // unsupported HTML, no style change
+                    break;
+            }
+        }
 
-		private static string CleanText(string s)
-		{
+        private static string CleanText(string s)
+        {
             // Need to convert HTML entities (named or numbered) into actual Unicode characters
 #if Core
             s = System.Net.WebUtility.HtmlDecode(s);
@@ -197,8 +197,8 @@ namespace OfficeOpenXml.Style
 #endif
             // Remove any non-breaking spaces, kills Excel
             s = s.Replace("\u00A0", " ");
-			return s;
-		}
+            return s;
+        }
 
-	}
+    }
 }

--- a/EPPlus/Table/ExcelTable.cs
+++ b/EPPlus/Table/ExcelTable.cs
@@ -130,7 +130,7 @@ namespace OfficeOpenXml.Table
         }
         internal ExcelTable(ExcelWorksheet sheet, ExcelAddressBase address, string name, int tblId) : 
             base(sheet.NameSpaceManager)
-	    {
+        {
             WorkSheet = sheet;
             Address = address;
             TableXml = new XmlDocument();

--- a/EPPlus/Table/ExcelTableColumn.cs
+++ b/EPPlus/Table/ExcelTableColumn.cs
@@ -215,26 +215,26 @@ namespace OfficeOpenXml.Table
                 }
             }
         }
-  		const string CALCULATEDCOLUMNFORMULA_PATH = "d:calculatedColumnFormula";
- 		/// <summary>
- 		/// Sets a calculated column Formula.
- 		/// Be carefull with this property since it is not validated. 
- 		/// <example>
- 		/// tbl.Columns[9].CalculatedColumnFormula = string.Format("SUM(MyDataTable[[#This Row],[{0}]])",tbl.Columns[9].Name);
- 		/// </example>
- 		/// </summary>
- 		public string CalculatedColumnFormula
- 		{
- 			get
- 			{
- 				return GetXmlNodeString(CALCULATEDCOLUMNFORMULA_PATH);
- 			}
- 			set
- 			{
- 				if (value.StartsWith("=")) value = value.Substring(1, value.Length - 1);
- 				SetXmlNodeString(CALCULATEDCOLUMNFORMULA_PATH, value);
- 			}
- 		}
+          const string CALCULATEDCOLUMNFORMULA_PATH = "d:calculatedColumnFormula";
+         /// <summary>
+         /// Sets a calculated column Formula.
+         /// Be carefull with this property since it is not validated. 
+         /// <example>
+         /// tbl.Columns[9].CalculatedColumnFormula = string.Format("SUM(MyDataTable[[#This Row],[{0}]])",tbl.Columns[9].Name);
+         /// </example>
+         /// </summary>
+         public string CalculatedColumnFormula
+         {
+             get
+             {
+                 return GetXmlNodeString(CALCULATEDCOLUMNFORMULA_PATH);
+             }
+             set
+             {
+                 if (value.StartsWith("=")) value = value.Substring(1, value.Length - 1);
+                 SetXmlNodeString(CALCULATEDCOLUMNFORMULA_PATH, value);
+             }
+         }
 
     }
 }

--- a/EPPlus/Table/PivotTable/ExcelPivotTable.cs
+++ b/EPPlus/Table/PivotTable/ExcelPivotTable.cs
@@ -126,7 +126,7 @@ namespace OfficeOpenXml.Table.PivotTable
         /// <param name="tblId"></param>
         internal ExcelPivotTable(ExcelWorksheet sheet, ExcelAddressBase address,ExcelRangeBase sourceAddress, string name, int tblId) : 
             base(sheet.NameSpaceManager)
-	    {
+        {
             WorkSheet = sheet;
             Address = address;
             var pck = sheet._package.Package;

--- a/EPPlus/Table/PivotTable/ExcelPivotTableFieldCollection.cs
+++ b/EPPlus/Table/PivotTable/ExcelPivotTableFieldCollection.cs
@@ -150,9 +150,9 @@ namespace OfficeOpenXml.Table.PivotTable
         internal string _topNode;
         internal ExcelPivotTableRowColumnFieldCollection(ExcelPivotTable table, string topNode) :
             base(table)
-	    {
+        {
             _topNode=topNode;
-	    }
+        }
 
         /// <summary>
         /// Add a new row/column field

--- a/EPPlus/Utils/ConvertUtil.cs
+++ b/EPPlus/Utils/ConvertUtil.cs
@@ -18,65 +18,65 @@ namespace OfficeOpenXml.Utils
             if (candidate == null) return false;
             return (TypeCompat.IsPrimitive(candidate) || candidate is double || candidate is decimal || candidate is DateTime || candidate is TimeSpan || candidate is long);
         }
-		/// <summary>
-		/// Tries to parse a double from the specified <paramref name="candidate"/> which is expected to be a string value.
-		/// </summary>
-		/// <param name="candidate">The string value.</param>
-		/// <param name="result">The double value parsed from the specified <paramref name="candidate"/>.</param>
-		/// <returns>True if <paramref name="candidate"/> could be parsed to a double; otherwise, false.</returns>
-		internal static bool TryParseNumericString(object candidate, out double result)
-		{
-			if (candidate != null)
-			{
-				// If a number is stored in a string, Excel will not convert it to the invariant format, so assume that it is in the current culture's number format.
-				// This may not always be true, but it is a better assumption than assuming it is always in the invariant culture, which will probably never be true
-				// for locales outside the United States.
-				var style = NumberStyles.Float | NumberStyles.AllowThousands;
-				return double.TryParse(candidate.ToString(), style, CultureInfo.CurrentCulture, out result);
-			}
-			result = 0;
-			return false;
-		}
-		/// <summary>
-		/// Tries to parse a boolean value from the specificed <paramref name="candidate"/>.
-		/// </summary>
-		/// <param name="candidate">The value to check for boolean-ness.</param>
-		/// <param name="result">The boolean value parsed from the specified <paramref name="candidate"/>.</param>
-		/// <returns>True if <paramref name="candidate"/> could be parsed </returns>
-		internal static bool TryParseBooleanString(object candidate, out bool result)
-		{
-			if (candidate != null)
-				return bool.TryParse(candidate.ToString(), out result);
-			result = false;
-			return false;
-		}
-		/// <summary>
-		/// Tries to parse a <see cref="DateTime"/> from the specified <paramref name="candidate"/> which is expected to be a string value.
-		/// </summary>
-		/// <param name="candidate">The string value.</param>
-		/// <param name="result">The double value parsed from the specified <paramref name="candidate"/>.</param>
-		/// <returns>True if <paramref name="candidate"/> could be parsed to a double; otherwise, false.</returns>
-		internal static bool TryParseDateString(object candidate, out DateTime result)
-		{
-			if (candidate != null)
-			{
-				var style = DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AssumeLocal;
-				// If a date is stored in a string, Excel will not convert it to the invariant format, so assume that it is in the current culture's date/time format.
-				// This may not always be true, but it is a better assumption than assuming it is always in the invariant culture, which will probably never be true
-				// for locales outside the United States.
-				return DateTime.TryParse(candidate.ToString(), CultureInfo.CurrentCulture, style, out result);
-			}
-			result = DateTime.MinValue;
-			return false;
-		}
-		/// <summary>
-		/// Convert an object value to a double 
-		/// </summary>
-		/// <param name="v"></param>
-		/// <param name="ignoreBool"></param>
+        /// <summary>
+        /// Tries to parse a double from the specified <paramref name="candidate"/> which is expected to be a string value.
+        /// </summary>
+        /// <param name="candidate">The string value.</param>
+        /// <param name="result">The double value parsed from the specified <paramref name="candidate"/>.</param>
+        /// <returns>True if <paramref name="candidate"/> could be parsed to a double; otherwise, false.</returns>
+        internal static bool TryParseNumericString(object candidate, out double result)
+        {
+            if (candidate != null)
+            {
+                // If a number is stored in a string, Excel will not convert it to the invariant format, so assume that it is in the current culture's number format.
+                // This may not always be true, but it is a better assumption than assuming it is always in the invariant culture, which will probably never be true
+                // for locales outside the United States.
+                var style = NumberStyles.Float | NumberStyles.AllowThousands;
+                return double.TryParse(candidate.ToString(), style, CultureInfo.CurrentCulture, out result);
+            }
+            result = 0;
+            return false;
+        }
+        /// <summary>
+        /// Tries to parse a boolean value from the specificed <paramref name="candidate"/>.
+        /// </summary>
+        /// <param name="candidate">The value to check for boolean-ness.</param>
+        /// <param name="result">The boolean value parsed from the specified <paramref name="candidate"/>.</param>
+        /// <returns>True if <paramref name="candidate"/> could be parsed </returns>
+        internal static bool TryParseBooleanString(object candidate, out bool result)
+        {
+            if (candidate != null)
+                return bool.TryParse(candidate.ToString(), out result);
+            result = false;
+            return false;
+        }
+        /// <summary>
+        /// Tries to parse a <see cref="DateTime"/> from the specified <paramref name="candidate"/> which is expected to be a string value.
+        /// </summary>
+        /// <param name="candidate">The string value.</param>
+        /// <param name="result">The double value parsed from the specified <paramref name="candidate"/>.</param>
+        /// <returns>True if <paramref name="candidate"/> could be parsed to a double; otherwise, false.</returns>
+        internal static bool TryParseDateString(object candidate, out DateTime result)
+        {
+            if (candidate != null)
+            {
+                var style = DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AssumeLocal;
+                // If a date is stored in a string, Excel will not convert it to the invariant format, so assume that it is in the current culture's date/time format.
+                // This may not always be true, but it is a better assumption than assuming it is always in the invariant culture, which will probably never be true
+                // for locales outside the United States.
+                return DateTime.TryParse(candidate.ToString(), CultureInfo.CurrentCulture, style, out result);
+            }
+            result = DateTime.MinValue;
+            return false;
+        }
+        /// <summary>
+        /// Convert an object value to a double 
+        /// </summary>
+        /// <param name="v"></param>
+        /// <param name="ignoreBool"></param>
         /// <param name="retNaN">Return NaN if invalid double otherwise 0</param>
-		/// <returns></returns>
-		internal static double GetValueDouble(object v, bool ignoreBool = false, bool retNaN=false)
+        /// <returns></returns>
+        internal static double GetValueDouble(object v, bool ignoreBool = false, bool retNaN=false)
         {
             double d;
             try

--- a/EPPlus/VBA/ExcelVBAModuleCollection.cs
+++ b/EPPlus/VBA/ExcelVBAModuleCollection.cs
@@ -121,9 +121,9 @@ namespace OfficeOpenXml.VBA
     {
         ExcelVbaProject _project;
         internal ExcelVbaModuleCollection (ExcelVbaProject project)
-	    {
+        {
             _project=project;
-	    }
+        }
         internal void Add(ExcelVBAModule Item)
         {
             _list.Add(Item);

--- a/EPPlus/XmlHelper.cs
+++ b/EPPlus/XmlHelper.cs
@@ -41,50 +41,50 @@ using System.Globalization;
 using System.IO;
 namespace OfficeOpenXml
 {
-	/// <summary>
-	/// Help class containing XML functions. 
-	/// Can be Inherited 
-	/// </summary>
-	public abstract class XmlHelper
-	{
-		internal delegate int ChangedEventHandler(StyleBase sender, Style.StyleChangeEventArgs e);
+    /// <summary>
+    /// Help class containing XML functions. 
+    /// Can be Inherited 
+    /// </summary>
+    public abstract class XmlHelper
+    {
+        internal delegate int ChangedEventHandler(StyleBase sender, Style.StyleChangeEventArgs e);
 
-		internal XmlHelper(XmlNamespaceManager nameSpaceManager)
-		{
-			TopNode = null;
-			NameSpaceManager = nameSpaceManager;
-		}
+        internal XmlHelper(XmlNamespaceManager nameSpaceManager)
+        {
+            TopNode = null;
+            NameSpaceManager = nameSpaceManager;
+        }
 
-		internal XmlHelper(XmlNamespaceManager nameSpaceManager, XmlNode topNode)
-		{
-			TopNode = topNode;
-			NameSpaceManager = nameSpaceManager;
-		}
-		//internal bool ChangedFlag;
-		internal XmlNamespaceManager NameSpaceManager { get; set; }
-		internal XmlNode TopNode { get; set; }
-		string[] _schemaNodeOrder = null;
-		/// <summary>
-		/// Schema order list
-		/// </summary>
-		internal string[] SchemaNodeOrder
-		{
-			get
-			{
-				return _schemaNodeOrder;
-			}
-			set
-			{
-				_schemaNodeOrder = value;
-			}
-		}
-		internal XmlNode CreateNode(string path)
-		{
-			if (path == "")
-				return TopNode;
-			else
-				return CreateNode(path, false);
-		}
+        internal XmlHelper(XmlNamespaceManager nameSpaceManager, XmlNode topNode)
+        {
+            TopNode = topNode;
+            NameSpaceManager = nameSpaceManager;
+        }
+        //internal bool ChangedFlag;
+        internal XmlNamespaceManager NameSpaceManager { get; set; }
+        internal XmlNode TopNode { get; set; }
+        string[] _schemaNodeOrder = null;
+        /// <summary>
+        /// Schema order list
+        /// </summary>
+        internal string[] SchemaNodeOrder
+        {
+            get
+            {
+                return _schemaNodeOrder;
+            }
+            set
+            {
+                _schemaNodeOrder = value;
+            }
+        }
+        internal XmlNode CreateNode(string path)
+        {
+            if (path == "")
+                return TopNode;
+            else
+                return CreateNode(path, false);
+        }
         /// <summary>
         /// Create the node path. Nodesa are inserted according to the Schema node oreder
         /// </summary>
@@ -93,594 +93,594 @@ namespace OfficeOpenXml
         /// <param name="addNew">Always add a new item at the last level.</param>
         /// <returns></returns>
         internal XmlNode CreateNode(string path, bool insertFirst, bool addNew=false)
-		{
-			XmlNode node = TopNode;
-			XmlNode prependNode = null;
+        {
+            XmlNode node = TopNode;
+            XmlNode prependNode = null;
             if (path.StartsWith("/")) path = path.Substring(1);
             var subPaths = path.Split('/');
             for(int i= 0; i < subPaths.Length;i++)
-			{
+            {
                 string subPath = subPaths[i];
                 XmlNode subNode = node.SelectSingleNode(subPath, NameSpaceManager);
-				if (subNode == null || (i==subPath.Length-1 && addNew))
-				{
-					string nodeName;
-					string nodePrefix;
+                if (subNode == null || (i==subPath.Length-1 && addNew))
+                {
+                    string nodeName;
+                    string nodePrefix;
 
-					string nameSpaceURI = "";
-					string[] nameSplit = subPath.Split(':');
+                    string nameSpaceURI = "";
+                    string[] nameSplit = subPath.Split(':');
 
-					if (SchemaNodeOrder != null && subPath[0] != '@')
-					{
-						insertFirst = false;
-						prependNode = GetPrependNode(subPath, node);
-					}
+                    if (SchemaNodeOrder != null && subPath[0] != '@')
+                    {
+                        insertFirst = false;
+                        prependNode = GetPrependNode(subPath, node);
+                    }
 
-					if (nameSplit.Length > 1)
-					{
-						nodePrefix = nameSplit[0];
-						if (nodePrefix[0] == '@') nodePrefix = nodePrefix.Substring(1, nodePrefix.Length - 1);
-						nameSpaceURI = NameSpaceManager.LookupNamespace(nodePrefix);
-						nodeName = nameSplit[1];
-					}
-					else
-					{
-						nodePrefix = "";
-						nameSpaceURI = "";
-						nodeName = nameSplit[0];
-					}
-					if (subPath.StartsWith("@"))
-					{
-						XmlAttribute addedAtt = node.OwnerDocument.CreateAttribute(subPath.Substring(1, subPath.Length - 1), nameSpaceURI);  //nameSpaceURI
-						node.Attributes.Append(addedAtt);
-					}
-					else
-					{
-						if (nodePrefix == "")
-						{
-							subNode = node.OwnerDocument.CreateElement(nodeName, nameSpaceURI);
-						}
-						else
-						{
-							if (nodePrefix == "" || (node.OwnerDocument != null && node.OwnerDocument.DocumentElement != null && node.OwnerDocument.DocumentElement.NamespaceURI == nameSpaceURI &&
-									node.OwnerDocument.DocumentElement.Prefix == ""))
-							{
-								subNode = node.OwnerDocument.CreateElement(nodeName, nameSpaceURI);
-							}
-							else
-							{
-								subNode = node.OwnerDocument.CreateElement(nodePrefix, nodeName, nameSpaceURI);
-							}
-						}
-						if (prependNode != null)
-						{
-							node.InsertBefore(subNode, prependNode);
-							prependNode = null;
-						}
-						else if (insertFirst)
-						{
-							node.PrependChild(subNode);
-						}
-						else
-						{
-							node.AppendChild(subNode);
-						}
-					}
-				}
-				node = subNode;
-			}
-			return node;
-		}
+                    if (nameSplit.Length > 1)
+                    {
+                        nodePrefix = nameSplit[0];
+                        if (nodePrefix[0] == '@') nodePrefix = nodePrefix.Substring(1, nodePrefix.Length - 1);
+                        nameSpaceURI = NameSpaceManager.LookupNamespace(nodePrefix);
+                        nodeName = nameSplit[1];
+                    }
+                    else
+                    {
+                        nodePrefix = "";
+                        nameSpaceURI = "";
+                        nodeName = nameSplit[0];
+                    }
+                    if (subPath.StartsWith("@"))
+                    {
+                        XmlAttribute addedAtt = node.OwnerDocument.CreateAttribute(subPath.Substring(1, subPath.Length - 1), nameSpaceURI);  //nameSpaceURI
+                        node.Attributes.Append(addedAtt);
+                    }
+                    else
+                    {
+                        if (nodePrefix == "")
+                        {
+                            subNode = node.OwnerDocument.CreateElement(nodeName, nameSpaceURI);
+                        }
+                        else
+                        {
+                            if (nodePrefix == "" || (node.OwnerDocument != null && node.OwnerDocument.DocumentElement != null && node.OwnerDocument.DocumentElement.NamespaceURI == nameSpaceURI &&
+                                    node.OwnerDocument.DocumentElement.Prefix == ""))
+                            {
+                                subNode = node.OwnerDocument.CreateElement(nodeName, nameSpaceURI);
+                            }
+                            else
+                            {
+                                subNode = node.OwnerDocument.CreateElement(nodePrefix, nodeName, nameSpaceURI);
+                            }
+                        }
+                        if (prependNode != null)
+                        {
+                            node.InsertBefore(subNode, prependNode);
+                            prependNode = null;
+                        }
+                        else if (insertFirst)
+                        {
+                            node.PrependChild(subNode);
+                        }
+                        else
+                        {
+                            node.AppendChild(subNode);
+                        }
+                    }
+                }
+                node = subNode;
+            }
+            return node;
+        }
 
-		/// <summary>
-		/// Options to insert a node in the XmlDocument
-		/// </summary>
-		internal enum eNodeInsertOrder
-		{
-			/// <summary>
-			/// Insert as first node of "topNode"
-			/// </summary>
-			First,
+        /// <summary>
+        /// Options to insert a node in the XmlDocument
+        /// </summary>
+        internal enum eNodeInsertOrder
+        {
+            /// <summary>
+            /// Insert as first node of "topNode"
+            /// </summary>
+            First,
 
-			/// <summary>
-			/// Insert as the last child of "topNode"
-			/// </summary>
-			Last,
+            /// <summary>
+            /// Insert as the last child of "topNode"
+            /// </summary>
+            Last,
 
-			/// <summary>
-			/// Insert after the "referenceNode"
-			/// </summary>
-			After,
+            /// <summary>
+            /// Insert after the "referenceNode"
+            /// </summary>
+            After,
 
-			/// <summary>
-			/// Insert before the "referenceNode"
-			/// </summary>
-			Before,
+            /// <summary>
+            /// Insert before the "referenceNode"
+            /// </summary>
+            Before,
 
-			/// <summary>
-			/// Use the Schema List to insert in the right order. If the Schema list
-			/// is null or empty, consider "Last" as the selected option
-			/// </summary>
-			SchemaOrder
-		}
+            /// <summary>
+            /// Use the Schema List to insert in the right order. If the Schema list
+            /// is null or empty, consider "Last" as the selected option
+            /// </summary>
+            SchemaOrder
+        }
 
-		/// <summary>
-		/// Create a complex node. Insert the node according to SchemaOrder
-		/// using the TopNode as the parent
-		/// </summary>
-		/// <param name="path"></param>
-		/// <returns></returns>
-		internal XmlNode CreateComplexNode(
-			string path)
-		{
-			return CreateComplexNode(
-				TopNode,
-				path,
-				eNodeInsertOrder.SchemaOrder,
-				null);
-		}
+        /// <summary>
+        /// Create a complex node. Insert the node according to SchemaOrder
+        /// using the TopNode as the parent
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        internal XmlNode CreateComplexNode(
+            string path)
+        {
+            return CreateComplexNode(
+                TopNode,
+                path,
+                eNodeInsertOrder.SchemaOrder,
+                null);
+        }
 
-		/// <summary>
-		/// Create a complex node. Insert the node according to the <paramref name="path"/>
-		/// using the <paramref name="topNode"/> as the parent
-		/// </summary>
-		/// <param name="topNode"></param>
-		/// <param name="path"></param>
-		/// <returns></returns>
-		internal XmlNode CreateComplexNode(
-			XmlNode topNode,
-			string path)
-		{
-			return CreateComplexNode(
-				topNode,
-				path,
-				eNodeInsertOrder.SchemaOrder,
-				null);
-		}
+        /// <summary>
+        /// Create a complex node. Insert the node according to the <paramref name="path"/>
+        /// using the <paramref name="topNode"/> as the parent
+        /// </summary>
+        /// <param name="topNode"></param>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        internal XmlNode CreateComplexNode(
+            XmlNode topNode,
+            string path)
+        {
+            return CreateComplexNode(
+                topNode,
+                path,
+                eNodeInsertOrder.SchemaOrder,
+                null);
+        }
 
-		/// <summary>
-		/// Creates complex XML nodes
+        /// <summary>
+        /// Creates complex XML nodes
     /// </summary>
     /// <remarks>
-		/// 1. "d:conditionalFormatting"
-		///		1.1. Creates/find the first "conditionalFormatting" node
-		/// 
-		/// 2. "d:conditionalFormatting/@sqref"
-		///		2.1. Creates/find the first "conditionalFormatting" node
-		///		2.2. Creates (if not exists) the @sqref attribute
-		///
-		/// 3. "d:conditionalFormatting/@id='7'/@sqref='A9:B99'"
-		///		3.1. Creates/find the first "conditionalFormatting" node
-		///		3.2. Creates/update its @id attribute to "7"
-		///		3.3. Creates/update its @sqref attribute to "A9:B99"
-		///
-		/// 4. "d:conditionalFormatting[@id='7']/@sqref='X1:X5'"
-		///		4.1. Creates/find the first "conditionalFormatting" node with @id=7
-		///		4.2. Creates/update its @sqref attribute to "X1:X5"
-		///	
-		/// 5. "d:conditionalFormatting[@id='7']/@id='8'/@sqref='X1:X5'/d:cfRule/@id='AB'"
-		///		5.1. Creates/find the first "conditionalFormatting" node with @id=7
-		///		5.2. Set its @id attribute to "8"
-		///		5.2. Creates/update its @sqref attribute and set it to "X1:X5"
-		///		5.3. Creates/find the first "cfRule" node (inside the node)
-		///		5.4. Creates/update its @id attribute to "AB"
-		///	
-		/// 6. "d:cfRule/@id=''"
-		///		6.1. Creates/find the first "cfRule" node
-		///		6.1. Remove the @id attribute
+        /// 1. "d:conditionalFormatting"
+        ///		1.1. Creates/find the first "conditionalFormatting" node
+        /// 
+        /// 2. "d:conditionalFormatting/@sqref"
+        ///		2.1. Creates/find the first "conditionalFormatting" node
+        ///		2.2. Creates (if not exists) the @sqref attribute
+        ///
+        /// 3. "d:conditionalFormatting/@id='7'/@sqref='A9:B99'"
+        ///		3.1. Creates/find the first "conditionalFormatting" node
+        ///		3.2. Creates/update its @id attribute to "7"
+        ///		3.3. Creates/update its @sqref attribute to "A9:B99"
+        ///
+        /// 4. "d:conditionalFormatting[@id='7']/@sqref='X1:X5'"
+        ///		4.1. Creates/find the first "conditionalFormatting" node with @id=7
+        ///		4.2. Creates/update its @sqref attribute to "X1:X5"
+        ///	
+        /// 5. "d:conditionalFormatting[@id='7']/@id='8'/@sqref='X1:X5'/d:cfRule/@id='AB'"
+        ///		5.1. Creates/find the first "conditionalFormatting" node with @id=7
+        ///		5.2. Set its @id attribute to "8"
+        ///		5.2. Creates/update its @sqref attribute and set it to "X1:X5"
+        ///		5.3. Creates/find the first "cfRule" node (inside the node)
+        ///		5.4. Creates/update its @id attribute to "AB"
+        ///	
+        /// 6. "d:cfRule/@id=''"
+        ///		6.1. Creates/find the first "cfRule" node
+        ///		6.1. Remove the @id attribute
     ///	</remarks>
-		/// <param name="topNode"></param>
-		/// <param name="path"></param>
-		/// <param name="nodeInsertOrder"></param>
-		/// <param name="referenceNode"></param>
-		/// <returns>The last node creates/found</returns>
-		internal XmlNode CreateComplexNode(
-			XmlNode topNode,
-			string path,
-			eNodeInsertOrder nodeInsertOrder,
-			XmlNode referenceNode)
-		{
-			// Path is obrigatory
-			if ((path == null) || (path == string.Empty))
-			{
-				return topNode;
-			}
+        /// <param name="topNode"></param>
+        /// <param name="path"></param>
+        /// <param name="nodeInsertOrder"></param>
+        /// <param name="referenceNode"></param>
+        /// <returns>The last node creates/found</returns>
+        internal XmlNode CreateComplexNode(
+            XmlNode topNode,
+            string path,
+            eNodeInsertOrder nodeInsertOrder,
+            XmlNode referenceNode)
+        {
+            // Path is obrigatory
+            if ((path == null) || (path == string.Empty))
+            {
+                return topNode;
+            }
 
-			XmlNode node = topNode;
-			string nameSpaceURI = string.Empty;
+            XmlNode node = topNode;
+            string nameSpaceURI = string.Empty;
 
       //TODO: BUG: when the "path" contains "/" in an attrribue value, it gives an error.
 
-			// Separate the XPath to Nodes and Attributes
-			foreach (string subPath in path.Split('/'))
-			{
-				// The subPath can be any one of those:
-				// nodeName
-				// x:nodeName
-				// nodeName[find criteria]
-				// x:nodeName[find criteria]
-				// @attribute
-				// @attribute='attribute value'
+            // Separate the XPath to Nodes and Attributes
+            foreach (string subPath in path.Split('/'))
+            {
+                // The subPath can be any one of those:
+                // nodeName
+                // x:nodeName
+                // nodeName[find criteria]
+                // x:nodeName[find criteria]
+                // @attribute
+                // @attribute='attribute value'
 
-				// Check if the subPath has at least one character
-				if (subPath.Length > 0)
-				{
-					// Check if the subPath is an attribute (with or without value)
-					if (subPath.StartsWith("@"))
-					{
-						// @attribute										--> Create attribute
-						// @attribute=''								--> Remove attribute
-						// @attribute='attribute value' --> Create attribute + update value
-						string[] attributeSplit = subPath.Split('=');
-						string attributeName = attributeSplit[0].Substring(1, attributeSplit[0].Length - 1);
-						string attributeValue = null;	// Null means no attribute value
+                // Check if the subPath has at least one character
+                if (subPath.Length > 0)
+                {
+                    // Check if the subPath is an attribute (with or without value)
+                    if (subPath.StartsWith("@"))
+                    {
+                        // @attribute										--> Create attribute
+                        // @attribute=''								--> Remove attribute
+                        // @attribute='attribute value' --> Create attribute + update value
+                        string[] attributeSplit = subPath.Split('=');
+                        string attributeName = attributeSplit[0].Substring(1, attributeSplit[0].Length - 1);
+                        string attributeValue = null;	// Null means no attribute value
                         
-						// Check if we have an attribute value to set
-						if (attributeSplit.Length > 1)
-						{
-							// Remove the ' or " from the attribute value
-							attributeValue = attributeSplit[1].Replace("'", "").Replace("\"", "");
-						}
+                        // Check if we have an attribute value to set
+                        if (attributeSplit.Length > 1)
+                        {
+                            // Remove the ' or " from the attribute value
+                            attributeValue = attributeSplit[1].Replace("'", "").Replace("\"", "");
+                        }
 
-						// Get the attribute (if exists)
-						XmlAttribute attribute = (XmlAttribute)(node.Attributes.GetNamedItem(attributeName));
+                        // Get the attribute (if exists)
+                        XmlAttribute attribute = (XmlAttribute)(node.Attributes.GetNamedItem(attributeName));
 
-						// Remove the attribute if value is empty (not null)
-						if (attributeValue == string.Empty)
-						{
-							// Only if the attribute exists
-							if (attribute != null)
-							{
-								node.Attributes.Remove(attribute);
-							}
-						}
-						else
-						{
-							// Create the attribue if does not exists
-							if (attribute == null)
-							{
-								// Create the attribute
-								attribute = node.OwnerDocument.CreateAttribute(
-									attributeName);
+                        // Remove the attribute if value is empty (not null)
+                        if (attributeValue == string.Empty)
+                        {
+                            // Only if the attribute exists
+                            if (attribute != null)
+                            {
+                                node.Attributes.Remove(attribute);
+                            }
+                        }
+                        else
+                        {
+                            // Create the attribue if does not exists
+                            if (attribute == null)
+                            {
+                                // Create the attribute
+                                attribute = node.OwnerDocument.CreateAttribute(
+                                    attributeName);
 
-								// Add it to the current node
-								node.Attributes.Append(attribute);
-							}
+                                // Add it to the current node
+                                node.Attributes.Append(attribute);
+                            }
 
-							// Update the attribute value
-							if (attributeValue != null)
-							{
-								node.Attributes[attributeName].Value = attributeValue;
-							}
-						}
-					}
-					else
-					{
-						// nodeName
-						// x:nodeName
-						// nodeName[find criteria]
-						// x:nodeName[find criteria]
+                            // Update the attribute value
+                            if (attributeValue != null)
+                            {
+                                node.Attributes[attributeName].Value = attributeValue;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // nodeName
+                        // x:nodeName
+                        // nodeName[find criteria]
+                        // x:nodeName[find criteria]
 
-						// Look for the node (with or without filter criteria)
-						XmlNode subNode = node.SelectSingleNode(subPath, NameSpaceManager);
+                        // Look for the node (with or without filter criteria)
+                        XmlNode subNode = node.SelectSingleNode(subPath, NameSpaceManager);
 
-						// Check if the node does not exists
-						if (subNode == null)
-						{
-							string nodeName;
-							string nodePrefix;
-							string[] nameSplit = subPath.Split(':');
-							nameSpaceURI = string.Empty;
+                        // Check if the node does not exists
+                        if (subNode == null)
+                        {
+                            string nodeName;
+                            string nodePrefix;
+                            string[] nameSplit = subPath.Split(':');
+                            nameSpaceURI = string.Empty;
 
-							// Check if the name has a prefix like "d:nodeName"
-							if (nameSplit.Length > 1)
-							{
-								nodePrefix = nameSplit[0];
-								nameSpaceURI = NameSpaceManager.LookupNamespace(nodePrefix);
-								nodeName = nameSplit[1];
-							}
-							else
-							{
-								nodePrefix = string.Empty;
-								nameSpaceURI = string.Empty;
-								nodeName = nameSplit[0];
-							}
+                            // Check if the name has a prefix like "d:nodeName"
+                            if (nameSplit.Length > 1)
+                            {
+                                nodePrefix = nameSplit[0];
+                                nameSpaceURI = NameSpaceManager.LookupNamespace(nodePrefix);
+                                nodeName = nameSplit[1];
+                            }
+                            else
+                            {
+                                nodePrefix = string.Empty;
+                                nameSpaceURI = string.Empty;
+                                nodeName = nameSplit[0];
+                            }
 
-							// Check if we have a criteria part in the node name
-							if (nodeName.IndexOf("[") > 0)
-							{
-								// remove the criteria from the node name
-								nodeName = nodeName.Substring(0, nodeName.IndexOf("["));
-							}
+                            // Check if we have a criteria part in the node name
+                            if (nodeName.IndexOf("[") > 0)
+                            {
+                                // remove the criteria from the node name
+                                nodeName = nodeName.Substring(0, nodeName.IndexOf("["));
+                            }
 
-							if (nodePrefix == string.Empty)
-							{
-								subNode = node.OwnerDocument.CreateElement(nodeName, nameSpaceURI);
-							}
-							else
-							{
-								if (node.OwnerDocument != null
-									&& node.OwnerDocument.DocumentElement != null
-									&& node.OwnerDocument.DocumentElement.NamespaceURI == nameSpaceURI
-									&& node.OwnerDocument.DocumentElement.Prefix == string.Empty)
-								{
-									subNode = node.OwnerDocument.CreateElement(
-										nodeName,
-										nameSpaceURI);
-								}
-								else
-								{
-									subNode = node.OwnerDocument.CreateElement(
-										nodePrefix,
-										nodeName,
-										nameSpaceURI);
-								}
-							}
+                            if (nodePrefix == string.Empty)
+                            {
+                                subNode = node.OwnerDocument.CreateElement(nodeName, nameSpaceURI);
+                            }
+                            else
+                            {
+                                if (node.OwnerDocument != null
+                                    && node.OwnerDocument.DocumentElement != null
+                                    && node.OwnerDocument.DocumentElement.NamespaceURI == nameSpaceURI
+                                    && node.OwnerDocument.DocumentElement.Prefix == string.Empty)
+                                {
+                                    subNode = node.OwnerDocument.CreateElement(
+                                        nodeName,
+                                        nameSpaceURI);
+                                }
+                                else
+                                {
+                                    subNode = node.OwnerDocument.CreateElement(
+                                        nodePrefix,
+                                        nodeName,
+                                        nameSpaceURI);
+                                }
+                            }
 
-							// Check if we need to use the "SchemaOrder"
-							if (nodeInsertOrder == eNodeInsertOrder.SchemaOrder)
-							{
-								// Check if the Schema Order List is empty
-								if ((SchemaNodeOrder == null) || (SchemaNodeOrder.Length == 0))
-								{
-									// Use the "Insert Last" option when Schema Order List is empty
-									nodeInsertOrder = eNodeInsertOrder.Last;
-								}
-								else
-								{
-									// Find the prepend node in order to insert
-									referenceNode = GetPrependNode(nodeName, node);
+                            // Check if we need to use the "SchemaOrder"
+                            if (nodeInsertOrder == eNodeInsertOrder.SchemaOrder)
+                            {
+                                // Check if the Schema Order List is empty
+                                if ((SchemaNodeOrder == null) || (SchemaNodeOrder.Length == 0))
+                                {
+                                    // Use the "Insert Last" option when Schema Order List is empty
+                                    nodeInsertOrder = eNodeInsertOrder.Last;
+                                }
+                                else
+                                {
+                                    // Find the prepend node in order to insert
+                                    referenceNode = GetPrependNode(nodeName, node);
 
-									if (referenceNode != null)
-									{
-										nodeInsertOrder = eNodeInsertOrder.Before;
-									}
-									else
-									{
-										nodeInsertOrder = eNodeInsertOrder.Last;
-									}
-								}
-							}
+                                    if (referenceNode != null)
+                                    {
+                                        nodeInsertOrder = eNodeInsertOrder.Before;
+                                    }
+                                    else
+                                    {
+                                        nodeInsertOrder = eNodeInsertOrder.Last;
+                                    }
+                                }
+                            }
 
-							switch (nodeInsertOrder)
-							{
-								case eNodeInsertOrder.After:
-									node.InsertAfter(subNode, referenceNode);
+                            switch (nodeInsertOrder)
+                            {
+                                case eNodeInsertOrder.After:
+                                    node.InsertAfter(subNode, referenceNode);
                                     referenceNode = null;
                                     break;
 
-								case eNodeInsertOrder.Before:
-									node.InsertBefore(subNode, referenceNode);
+                                case eNodeInsertOrder.Before:
+                                    node.InsertBefore(subNode, referenceNode);
                                     referenceNode = null;
-									break;
+                                    break;
 
-								case eNodeInsertOrder.First:
-									node.PrependChild(subNode);
-									break;
+                                case eNodeInsertOrder.First:
+                                    node.PrependChild(subNode);
+                                    break;
 
-								case eNodeInsertOrder.Last:
-									node.AppendChild(subNode);
-									break;
-							}
-						}
+                                case eNodeInsertOrder.Last:
+                                    node.AppendChild(subNode);
+                                    break;
+                            }
+                        }
 
-						// Make the newly created node the top node when the rest of the path
-						// is being evaluated. So newly created nodes will be the children of the
-						// one we just created.
-						node = subNode;
-					}
-				}
-			}
+                        // Make the newly created node the top node when the rest of the path
+                        // is being evaluated. So newly created nodes will be the children of the
+                        // one we just created.
+                        node = subNode;
+                    }
+                }
+            }
 
-			// Return the last created/found node
-			return node;
-		}
+            // Return the last created/found node
+            return node;
+        }
 
-		/// <summary>
-		/// return Prepend node
-		/// </summary>
-		/// <param name="nodeName">name of the node to check</param>
-		/// <param name="node">Topnode to check children</param>
-		/// <returns></returns>
-		private XmlNode GetPrependNode(string nodeName, XmlNode node)
-		{
-			int pos = GetNodePos(nodeName);
-			if (pos < 0)
-			{
-				return null;
-			}
-			XmlNode prependNode = null;
-			foreach (XmlNode childNode in node.ChildNodes)
-			{
-				int childPos = GetNodePos(childNode.Name);
-				if (childPos > -1)  //Found?
-				{
-					if (childPos > pos) //Position is before
-					{
-						prependNode = childNode;
-						break;
-					}
-				}
-			}
-			return prependNode;
-		}
-		private int GetNodePos(string nodeName)
-		{
-			int ix = nodeName.IndexOf(":");
-			if (ix > 0)
-			{
-				nodeName = nodeName.Substring(ix + 1, nodeName.Length - (ix + 1));
-			}
-			for (int i = 0; i < _schemaNodeOrder.Length; i++)
-			{
-				if (nodeName == _schemaNodeOrder[i])
-				{
-					return i;
-				}
-			}
-			return -1;
-		}
-		internal void DeleteAllNode(string path)
-		{
-			string[] split = path.Split('/');
-			XmlNode node = TopNode;
-			foreach (string s in split)
-			{
-				node = node.SelectSingleNode(s, NameSpaceManager);
-				if (node != null)
-				{
-					if (node is XmlAttribute)
-					{
-						(node as XmlAttribute).OwnerElement.Attributes.Remove(node as XmlAttribute);
-					}
-					else
-					{
-						node.ParentNode.RemoveChild(node);
-					}
-				}
-				else
-				{
-					break;
-				}
-			}
-		}
-		internal void DeleteNode(string path)
-		{
-			var node = TopNode.SelectSingleNode(path, NameSpaceManager);
-			if (node != null)
-			{
-				if (node is XmlAttribute)
-				{
-					var att = (XmlAttribute)node;
-					att.OwnerElement.Attributes.Remove(att);
-				}
-				else
-				{
-					node.ParentNode.RemoveChild(node);
-				}
-			}
-		}
+        /// <summary>
+        /// return Prepend node
+        /// </summary>
+        /// <param name="nodeName">name of the node to check</param>
+        /// <param name="node">Topnode to check children</param>
+        /// <returns></returns>
+        private XmlNode GetPrependNode(string nodeName, XmlNode node)
+        {
+            int pos = GetNodePos(nodeName);
+            if (pos < 0)
+            {
+                return null;
+            }
+            XmlNode prependNode = null;
+            foreach (XmlNode childNode in node.ChildNodes)
+            {
+                int childPos = GetNodePos(childNode.Name);
+                if (childPos > -1)  //Found?
+                {
+                    if (childPos > pos) //Position is before
+                    {
+                        prependNode = childNode;
+                        break;
+                    }
+                }
+            }
+            return prependNode;
+        }
+        private int GetNodePos(string nodeName)
+        {
+            int ix = nodeName.IndexOf(":");
+            if (ix > 0)
+            {
+                nodeName = nodeName.Substring(ix + 1, nodeName.Length - (ix + 1));
+            }
+            for (int i = 0; i < _schemaNodeOrder.Length; i++)
+            {
+                if (nodeName == _schemaNodeOrder[i])
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+        internal void DeleteAllNode(string path)
+        {
+            string[] split = path.Split('/');
+            XmlNode node = TopNode;
+            foreach (string s in split)
+            {
+                node = node.SelectSingleNode(s, NameSpaceManager);
+                if (node != null)
+                {
+                    if (node is XmlAttribute)
+                    {
+                        (node as XmlAttribute).OwnerElement.Attributes.Remove(node as XmlAttribute);
+                    }
+                    else
+                    {
+                        node.ParentNode.RemoveChild(node);
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        internal void DeleteNode(string path)
+        {
+            var node = TopNode.SelectSingleNode(path, NameSpaceManager);
+            if (node != null)
+            {
+                if (node is XmlAttribute)
+                {
+                    var att = (XmlAttribute)node;
+                    att.OwnerElement.Attributes.Remove(att);
+                }
+                else
+                {
+                    node.ParentNode.RemoveChild(node);
+                }
+            }
+        }
     internal void DeleteTopNode()
     {
       TopNode.ParentNode.RemoveChild(TopNode);
     }
-		internal void SetXmlNodeString(string path, string value)
-		{
-			SetXmlNodeString(TopNode, path, value, false, false);
-		}
-		internal void SetXmlNodeString(string path, string value, bool removeIfBlank)
-		{
-			SetXmlNodeString(TopNode, path, value, removeIfBlank, false);
-		}
-		internal void SetXmlNodeString(XmlNode node, string path, string value)
-		{
-			SetXmlNodeString(node, path, value, false, false);
-		}
-		internal void SetXmlNodeString(XmlNode node, string path, string value, bool removeIfBlank)
-		{
-			SetXmlNodeString(node, path, value, removeIfBlank, false);
-		}
-		internal void SetXmlNodeString(XmlNode node, string path, string value, bool removeIfBlank, bool insertFirst)
-		{
-			if (node == null)
-			{
-				return;
-			}
-			if (value == "" && removeIfBlank)
-			{
-				DeleteAllNode(path);
-			}
-			else
-			{
-				XmlNode nameNode = node.SelectSingleNode(path, NameSpaceManager);
-				if (nameNode == null)
-				{
-					CreateNode(path, insertFirst);
-					nameNode = node.SelectSingleNode(path, NameSpaceManager);
-				}
-				//if (nameNode.InnerText != value) HasChanged();
-				nameNode.InnerText = value;
-			}
-		}
-		internal void SetXmlNodeBool(string path, bool value)
-		{
-			SetXmlNodeString(TopNode, path, value ? "1" : "0", false, false);
-		}
-		internal void SetXmlNodeBool(string path, bool value, bool removeIf)
-		{
-			if (value == removeIf)
-			{
-				var node = TopNode.SelectSingleNode(path, NameSpaceManager);
-				if (node != null)
-				{
-					if (node is XmlAttribute)
-					{
-						var elem = (node as XmlAttribute).OwnerElement;
-						elem.ParentNode.RemoveChild(elem);
-					}
-					else
-					{
-						TopNode.RemoveChild(node);
-					}
-				}
-			}
-			else
-			{
-				SetXmlNodeString(TopNode, path, value ? "1" : "0", false, false);
-			}
-		}
-		internal bool ExistNode(string path)
-		{
-			if (TopNode == null || TopNode.SelectSingleNode(path, NameSpaceManager) == null)
-			{
-				return false;
-			}
-			else
-			{
-				return true;
-			}
-		}
-		internal bool? GetXmlNodeBoolNullable(string path)
-		{
-			var value = GetXmlNodeString(path);
-			if (string.IsNullOrEmpty(value))
-			{
-				return null;
-			}
-			return GetXmlNodeBool(path);
-		}
-		internal bool GetXmlNodeBool(string path)
-		{
-			return GetXmlNodeBool(path, false);
-		}
-		internal bool GetXmlNodeBool(string path, bool blankValue)
-		{
-			string value = GetXmlNodeString(path);
-			if (value == "1" || value == "-1" || value.Equals("true",StringComparison.OrdinalIgnoreCase))
-			{
-				return true;
-			}
-			else if (value == "")
-			{
-				return blankValue;
-			}
-			else
-			{
-				return false;
-			}
-		}
-		internal int GetXmlNodeInt(string path)
-		{
-			int i;
-			if (int.TryParse(GetXmlNodeString(path), NumberStyles.Number, CultureInfo.InvariantCulture, out i))
-			{
-				return i;
-			}
-			else
-			{
-				return int.MinValue;
-			}
-		}
+        internal void SetXmlNodeString(string path, string value)
+        {
+            SetXmlNodeString(TopNode, path, value, false, false);
+        }
+        internal void SetXmlNodeString(string path, string value, bool removeIfBlank)
+        {
+            SetXmlNodeString(TopNode, path, value, removeIfBlank, false);
+        }
+        internal void SetXmlNodeString(XmlNode node, string path, string value)
+        {
+            SetXmlNodeString(node, path, value, false, false);
+        }
+        internal void SetXmlNodeString(XmlNode node, string path, string value, bool removeIfBlank)
+        {
+            SetXmlNodeString(node, path, value, removeIfBlank, false);
+        }
+        internal void SetXmlNodeString(XmlNode node, string path, string value, bool removeIfBlank, bool insertFirst)
+        {
+            if (node == null)
+            {
+                return;
+            }
+            if (value == "" && removeIfBlank)
+            {
+                DeleteAllNode(path);
+            }
+            else
+            {
+                XmlNode nameNode = node.SelectSingleNode(path, NameSpaceManager);
+                if (nameNode == null)
+                {
+                    CreateNode(path, insertFirst);
+                    nameNode = node.SelectSingleNode(path, NameSpaceManager);
+                }
+                //if (nameNode.InnerText != value) HasChanged();
+                nameNode.InnerText = value;
+            }
+        }
+        internal void SetXmlNodeBool(string path, bool value)
+        {
+            SetXmlNodeString(TopNode, path, value ? "1" : "0", false, false);
+        }
+        internal void SetXmlNodeBool(string path, bool value, bool removeIf)
+        {
+            if (value == removeIf)
+            {
+                var node = TopNode.SelectSingleNode(path, NameSpaceManager);
+                if (node != null)
+                {
+                    if (node is XmlAttribute)
+                    {
+                        var elem = (node as XmlAttribute).OwnerElement;
+                        elem.ParentNode.RemoveChild(elem);
+                    }
+                    else
+                    {
+                        TopNode.RemoveChild(node);
+                    }
+                }
+            }
+            else
+            {
+                SetXmlNodeString(TopNode, path, value ? "1" : "0", false, false);
+            }
+        }
+        internal bool ExistNode(string path)
+        {
+            if (TopNode == null || TopNode.SelectSingleNode(path, NameSpaceManager) == null)
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+        internal bool? GetXmlNodeBoolNullable(string path)
+        {
+            var value = GetXmlNodeString(path);
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+            return GetXmlNodeBool(path);
+        }
+        internal bool GetXmlNodeBool(string path)
+        {
+            return GetXmlNodeBool(path, false);
+        }
+        internal bool GetXmlNodeBool(string path, bool blankValue)
+        {
+            string value = GetXmlNodeString(path);
+            if (value == "1" || value == "-1" || value.Equals("true",StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+            else if (value == "")
+            {
+                return blankValue;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        internal int GetXmlNodeInt(string path)
+        {
+            int i;
+            if (int.TryParse(GetXmlNodeString(path), NumberStyles.Number, CultureInfo.InvariantCulture, out i))
+            {
+                return i;
+            }
+            else
+            {
+                return int.MinValue;
+            }
+        }
         internal int? GetXmlNodeIntNull(string path)
         {
             int i;
@@ -695,18 +695,18 @@ namespace OfficeOpenXml
             }
         }
 
-		internal decimal GetXmlNodeDecimal(string path)
-		{
-			decimal d;
-			if (decimal.TryParse(GetXmlNodeString(path), NumberStyles.Any, CultureInfo.InvariantCulture, out d))
-			{
-				return d;
-			}
-			else
-			{
-				return 0;
-			}
-		}
+        internal decimal GetXmlNodeDecimal(string path)
+        {
+            decimal d;
+            if (decimal.TryParse(GetXmlNodeString(path), NumberStyles.Any, CultureInfo.InvariantCulture, out d))
+            {
+                return d;
+            }
+            else
+            {
+                return 0;
+            }
+        }
         internal decimal? GetXmlNodeDecimalNull(string path)
         {
             decimal d;
@@ -720,45 +720,45 @@ namespace OfficeOpenXml
             }
         }
         internal double? GetXmlNodeDoubleNull(string path)
-		{
-			string s = GetXmlNodeString(path);
-			if (s == "")
-			{
-				return null;
-			}
-			else
-			{
-				double v;
-                if (double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out v))
-				{
-					return v;
-				}
-				else
-				{
-					return null;
-				}
-			}
-		}		
-        internal double GetXmlNodeDouble(string path)
-		{
-			string s = GetXmlNodeString(path);
-			if (s == "")
-			{
-				return double.NaN;
-			}
-			else
-			{
+        {
+            string s = GetXmlNodeString(path);
+            if (s == "")
+            {
+                return null;
+            }
+            else
+            {
                 double v;
-				if (double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out v))
-				{
-					return v;
-				}
-				else
-				{
-					return double.NaN;
-				}
-			}
-		}
+                if (double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out v))
+                {
+                    return v;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }		
+        internal double GetXmlNodeDouble(string path)
+        {
+            string s = GetXmlNodeString(path);
+            if (s == "")
+            {
+                return double.NaN;
+            }
+            else
+            {
+                double v;
+                if (double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out v))
+                {
+                    return v;
+                }
+                else
+                {
+                    return double.NaN;
+                }
+            }
+        }
 
     internal string GetXmlNodeString(XmlNode node, string path)
     {
@@ -785,10 +785,10 @@ namespace OfficeOpenXml
         return "";
       }
     }
-		internal string GetXmlNodeString(string path)
-		{
+        internal string GetXmlNodeString(string path)
+        {
             return GetXmlNodeString(TopNode, path);
-		}
+        }
         internal static Uri GetNewUri(Packaging.ZipPackage package, string sUri)
         {
             var id = 1;
@@ -810,20 +810,20 @@ namespace OfficeOpenXml
         /// <param name="beforeNodes">comma separated list containing nodes to insert after. Left to right order</param>
         /// <param name="newNode">The new node to be inserterd</param>
         internal void InserAfter(XmlNode parentNode, string beforeNodes, XmlNode newNode)
-		{
-			string[] nodePaths = beforeNodes.Split(',');
+        {
+            string[] nodePaths = beforeNodes.Split(',');
 
-			foreach (string nodePath in nodePaths)
-			{
-				XmlNode node = parentNode.SelectSingleNode(nodePath, NameSpaceManager);
-				if (node != null)
-				{
-					parentNode.InsertAfter(newNode, node);
-					return;
-				}
-			}
-			parentNode.InsertAfter(newNode, null);
-		}
+            foreach (string nodePath in nodePaths)
+            {
+                XmlNode node = parentNode.SelectSingleNode(nodePath, NameSpaceManager);
+                if (node != null)
+                {
+                    parentNode.InsertAfter(newNode, node);
+                    return;
+                }
+            }
+            parentNode.InsertAfter(newNode, null);
+        }
         internal static void LoadXmlSafe(XmlDocument xmlDoc, Stream stream)
         {
             XmlReaderSettings settings = new XmlReaderSettings();
@@ -841,5 +841,5 @@ namespace OfficeOpenXml
             var stream = new MemoryStream(encoding.GetBytes(xml));
             LoadXmlSafe(xmlDoc, stream);
         }
-	}
+    }
 }

--- a/EPPlusTest/Calculation.cs
+++ b/EPPlusTest/Calculation.cs
@@ -151,7 +151,7 @@ namespace EPPlusTest
                     nErrors++;
                 }
             }
-		}
+        }
         [Ignore]
         [TestMethod]
         public void TestOneCell()
@@ -306,37 +306,37 @@ namespace EPPlusTest
 
             }
         }
-		[TestMethod]
-		public void CalculateDateMath()
-		{
-			using (ExcelPackage package = new ExcelPackage())
-			{
-				var worksheet = package.Workbook.Worksheets.Add("Test");
-				var dateCell = worksheet.Cells[2, 2];
-				var date = new DateTime(2013, 1, 1);
-				dateCell.Value = date;
-				var quotedDateCell = worksheet.Cells[2, 3];
-				quotedDateCell.Formula = $"\"{date.ToString("d")}\"";
-				var dateFormula = "B2";
-				var dateFormulaWithMath = "B2+1";
-				var quotedDateFormulaWithMath = $"\"{date.ToString("d")}\"+1";
-				var quotedDateReferenceFormulaWithMath = "C2+1";
-				var expectedDate = 41275.0; // January 1, 2013
-				var expectedDateWithMath = 41276.0; // January 2, 2013
-				Assert.AreEqual(expectedDate, worksheet.Calculate(dateFormula));
-				Assert.AreEqual(expectedDateWithMath, worksheet.Calculate(dateFormulaWithMath));
-				Assert.AreEqual(expectedDateWithMath, worksheet.Calculate(quotedDateFormulaWithMath));
-				Assert.AreEqual(expectedDateWithMath, worksheet.Calculate(quotedDateReferenceFormulaWithMath));
-				var formulaCell = worksheet.Cells[2, 4];
-				formulaCell.Formula = dateFormulaWithMath;
-				formulaCell.Calculate();
-				Assert.AreEqual(expectedDateWithMath, formulaCell.Value);
-				formulaCell.Formula = quotedDateReferenceFormulaWithMath;
-				formulaCell.Calculate();
-				Assert.AreEqual(expectedDateWithMath, formulaCell.Value);
-			}
-		}
-		private string GetOutput(string file)
+        [TestMethod]
+        public void CalculateDateMath()
+        {
+            using (ExcelPackage package = new ExcelPackage())
+            {
+                var worksheet = package.Workbook.Worksheets.Add("Test");
+                var dateCell = worksheet.Cells[2, 2];
+                var date = new DateTime(2013, 1, 1);
+                dateCell.Value = date;
+                var quotedDateCell = worksheet.Cells[2, 3];
+                quotedDateCell.Formula = $"\"{date.ToString("d")}\"";
+                var dateFormula = "B2";
+                var dateFormulaWithMath = "B2+1";
+                var quotedDateFormulaWithMath = $"\"{date.ToString("d")}\"+1";
+                var quotedDateReferenceFormulaWithMath = "C2+1";
+                var expectedDate = 41275.0; // January 1, 2013
+                var expectedDateWithMath = 41276.0; // January 2, 2013
+                Assert.AreEqual(expectedDate, worksheet.Calculate(dateFormula));
+                Assert.AreEqual(expectedDateWithMath, worksheet.Calculate(dateFormulaWithMath));
+                Assert.AreEqual(expectedDateWithMath, worksheet.Calculate(quotedDateFormulaWithMath));
+                Assert.AreEqual(expectedDateWithMath, worksheet.Calculate(quotedDateReferenceFormulaWithMath));
+                var formulaCell = worksheet.Cells[2, 4];
+                formulaCell.Formula = dateFormulaWithMath;
+                formulaCell.Calculate();
+                Assert.AreEqual(expectedDateWithMath, formulaCell.Value);
+                formulaCell.Formula = quotedDateReferenceFormulaWithMath;
+                formulaCell.Calculate();
+                Assert.AreEqual(expectedDateWithMath, formulaCell.Value);
+            }
+        }
+        private string GetOutput(string file)
         {
             using (var pck = new ExcelPackage(new FileInfo(file)))
             {

--- a/EPPlusTest/FormulaParsing/Excel/Functions/Math/AverageATests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/Math/AverageATests.cs
@@ -9,122 +9,122 @@ using OfficeOpenXml.FormulaParsing.Exceptions;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
 {
-	[TestClass]
-	public class AverageATests
-	{
-		[TestMethod]
-		public void AverageALiterals()
-		{
-			// For literals, AverageA always parses and include numeric strings, date strings, bools, etc.
-			// The only exception is unparsable string literals, which cause a #VALUE.
-			AverageA average = new AverageA();
-			var date1 = new DateTime(2013, 1, 5);
-			var date2 = new DateTime(2013, 1, 15);
-			double value1 = 1000;
-			double value2 = 2000;
-			double value3 = 6000;
-			double value4 = 1;
-			double value5 = date1.ToOADate();
-			double value6 = date2.ToOADate();
-			var result = average.Execute(new FunctionArgument[]
-			{
-				new FunctionArgument(value1.ToString("n")),
-				new FunctionArgument(value2),
-				new FunctionArgument(value3.ToString("n")),
-				new FunctionArgument(true),
-				new FunctionArgument(date1),
-				new FunctionArgument(date2.ToString("d"))
-			}, ParsingContext.Create());
-			Assert.AreEqual((value1 + value2 + value3 + value4 + value5 + value6) / 6, result.Result);
-		}
+    [TestClass]
+    public class AverageATests
+    {
+        [TestMethod]
+        public void AverageALiterals()
+        {
+            // For literals, AverageA always parses and include numeric strings, date strings, bools, etc.
+            // The only exception is unparsable string literals, which cause a #VALUE.
+            AverageA average = new AverageA();
+            var date1 = new DateTime(2013, 1, 5);
+            var date2 = new DateTime(2013, 1, 15);
+            double value1 = 1000;
+            double value2 = 2000;
+            double value3 = 6000;
+            double value4 = 1;
+            double value5 = date1.ToOADate();
+            double value6 = date2.ToOADate();
+            var result = average.Execute(new FunctionArgument[]
+            {
+                new FunctionArgument(value1.ToString("n")),
+                new FunctionArgument(value2),
+                new FunctionArgument(value3.ToString("n")),
+                new FunctionArgument(true),
+                new FunctionArgument(date1),
+                new FunctionArgument(date2.ToString("d"))
+            }, ParsingContext.Create());
+            Assert.AreEqual((value1 + value2 + value3 + value4 + value5 + value6) / 6, result.Result);
+        }
 
-		[TestMethod]
-		public void AverageACellReferences()
-		{
-			// For cell references, AverageA divides by all cells, but only adds actual numbers, dates, and booleans.
-			ExcelPackage package = new ExcelPackage();
-			var worksheet = package.Workbook.Worksheets.Add("Test");
-			double[] values =
-			{
-				0,
-				2000,
-				0,
-				1,
-				new DateTime(2013, 1, 5).ToOADate(),
-				0
-			};
-			ExcelRange range1 = worksheet.Cells[1, 1];
-			range1.Formula = "\"1000\"";
-			range1.Calculate();
-			var range2 = worksheet.Cells[1, 2];
-			range2.Value = 2000;
-			var range3 = worksheet.Cells[1, 3];
-			range3.Formula = $"\"{new DateTime(2013, 1, 5).ToString("d")}\"";
-			range3.Calculate();
-			var range4 = worksheet.Cells[1, 4];
-			range4.Value = true;
-			var range5 = worksheet.Cells[1, 5];
-			range5.Value = new DateTime(2013, 1, 5);
-			var range6 = worksheet.Cells[1, 6];
-			range6.Value = "Test";
-			AverageA average = new AverageA();
-			var rangeInfo1 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 1, 1, 3);
-			var rangeInfo2 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 4, 1, 4);
-			var rangeInfo3 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 5, 1, 6);
-			var context = ParsingContext.Create();
-			var address = new OfficeOpenXml.FormulaParsing.ExcelUtilities.RangeAddress();
-			address.FromRow = address.ToRow = address.FromCol = address.ToCol = 2;
-			context.Scopes.NewScope(address);
-			var result = average.Execute(new FunctionArgument[]
-			{
-				new FunctionArgument(rangeInfo1),
-				new FunctionArgument(rangeInfo2),
-				new FunctionArgument(rangeInfo3)
-			}, context);
-			Assert.AreEqual(values.Average(), result.Result);
-		}
+        [TestMethod]
+        public void AverageACellReferences()
+        {
+            // For cell references, AverageA divides by all cells, but only adds actual numbers, dates, and booleans.
+            ExcelPackage package = new ExcelPackage();
+            var worksheet = package.Workbook.Worksheets.Add("Test");
+            double[] values =
+            {
+                0,
+                2000,
+                0,
+                1,
+                new DateTime(2013, 1, 5).ToOADate(),
+                0
+            };
+            ExcelRange range1 = worksheet.Cells[1, 1];
+            range1.Formula = "\"1000\"";
+            range1.Calculate();
+            var range2 = worksheet.Cells[1, 2];
+            range2.Value = 2000;
+            var range3 = worksheet.Cells[1, 3];
+            range3.Formula = $"\"{new DateTime(2013, 1, 5).ToString("d")}\"";
+            range3.Calculate();
+            var range4 = worksheet.Cells[1, 4];
+            range4.Value = true;
+            var range5 = worksheet.Cells[1, 5];
+            range5.Value = new DateTime(2013, 1, 5);
+            var range6 = worksheet.Cells[1, 6];
+            range6.Value = "Test";
+            AverageA average = new AverageA();
+            var rangeInfo1 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 1, 1, 3);
+            var rangeInfo2 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 4, 1, 4);
+            var rangeInfo3 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 5, 1, 6);
+            var context = ParsingContext.Create();
+            var address = new OfficeOpenXml.FormulaParsing.ExcelUtilities.RangeAddress();
+            address.FromRow = address.ToRow = address.FromCol = address.ToCol = 2;
+            context.Scopes.NewScope(address);
+            var result = average.Execute(new FunctionArgument[]
+            {
+                new FunctionArgument(rangeInfo1),
+                new FunctionArgument(rangeInfo2),
+                new FunctionArgument(rangeInfo3)
+            }, context);
+            Assert.AreEqual(values.Average(), result.Result);
+        }
 
-		[TestMethod]
-		public void AverageAArray()
-		{
-			// For arrays, AverageA completely ignores booleans.  It divides by strings and numbers, but only
-			// numbers are added to the total.  Real dates cannot be specified and string dates are not parsed.
-			AverageA average = new AverageA();
-			var date = new DateTime(2013, 1, 15);
-			double[] values =
-			{
-				0,
-				2000,
-				0,
-				0,
-				0
-			};
-			var result = average.Execute(new FunctionArgument[]
-			{
-				new FunctionArgument(new FunctionArgument[]
-				{
-					new FunctionArgument(1000.ToString("n")),
-					new FunctionArgument(2000),
-					new FunctionArgument(6000.ToString("n")),
-					new FunctionArgument(true),
-					new FunctionArgument(date.ToString("d")),
-					new FunctionArgument("test")
-				})
-			}, ParsingContext.Create());
-			Assert.AreEqual(values.Average(), result.Result);
-		}
+        [TestMethod]
+        public void AverageAArray()
+        {
+            // For arrays, AverageA completely ignores booleans.  It divides by strings and numbers, but only
+            // numbers are added to the total.  Real dates cannot be specified and string dates are not parsed.
+            AverageA average = new AverageA();
+            var date = new DateTime(2013, 1, 15);
+            double[] values =
+            {
+                0,
+                2000,
+                0,
+                0,
+                0
+            };
+            var result = average.Execute(new FunctionArgument[]
+            {
+                new FunctionArgument(new FunctionArgument[]
+                {
+                    new FunctionArgument(1000.ToString("n")),
+                    new FunctionArgument(2000),
+                    new FunctionArgument(6000.ToString("n")),
+                    new FunctionArgument(true),
+                    new FunctionArgument(date.ToString("d")),
+                    new FunctionArgument("test")
+                })
+            }, ParsingContext.Create());
+            Assert.AreEqual(values.Average(), result.Result);
+        }
 
-		[TestMethod]
-		[ExpectedException(typeof(ExcelErrorValueException))]
-		public void AverageAUnparsableLiteral()
-		{
-			// In the case of literals, any unparsable string literal results in a #VALUE.
-			AverageA average = new AverageA();
-			var result = average.Execute(new FunctionArgument[]
-			{
-				new FunctionArgument(1000),
-				new FunctionArgument("Test")
-			}, ParsingContext.Create());
-		}
-	}
+        [TestMethod]
+        [ExpectedException(typeof(ExcelErrorValueException))]
+        public void AverageAUnparsableLiteral()
+        {
+            // In the case of literals, any unparsable string literal results in a #VALUE.
+            AverageA average = new AverageA();
+            var result = average.Execute(new FunctionArgument[]
+            {
+                new FunctionArgument(1000),
+                new FunctionArgument("Test")
+            }, ParsingContext.Create());
+        }
+    }
 }

--- a/EPPlusTest/FormulaParsing/Excel/Functions/Math/AverageTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/Math/AverageTests.cs
@@ -8,106 +8,106 @@ using OfficeOpenXml.FormulaParsing.Exceptions;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
 {
-	[TestClass]
-	public class AverageTests
-	{
-		[TestMethod]
-		public void AverageLiterals()
-		{
-			// In the case of literals, Average DOES parse and include numeric strings, date strings, bools, etc.
-			Average average = new Average();
-			var date1 = new DateTime(2013, 1, 5);
-			var date2 = new DateTime(2013, 1, 15);
-			double value1 = 1000;
-			double value2 = 2000;
-			double value3 = 6000;
-			double value4 = 1;
-			double value5 = date1.ToOADate();
-			double value6 = date2.ToOADate();
-			var result = average.Execute(new FunctionArgument[]
-			{
-				new FunctionArgument(value1.ToString("n")),
-				new FunctionArgument(value2),
-				new FunctionArgument(value3.ToString("n")),
-				new FunctionArgument(true),
-				new FunctionArgument(date1),
-				new FunctionArgument(date2.ToString("d"))
-			}, ParsingContext.Create());
-			Assert.AreEqual((value1 + value2 + value3 + value4 + value5 + value6) / 6, result.Result);
-		}
+    [TestClass]
+    public class AverageTests
+    {
+        [TestMethod]
+        public void AverageLiterals()
+        {
+            // In the case of literals, Average DOES parse and include numeric strings, date strings, bools, etc.
+            Average average = new Average();
+            var date1 = new DateTime(2013, 1, 5);
+            var date2 = new DateTime(2013, 1, 15);
+            double value1 = 1000;
+            double value2 = 2000;
+            double value3 = 6000;
+            double value4 = 1;
+            double value5 = date1.ToOADate();
+            double value6 = date2.ToOADate();
+            var result = average.Execute(new FunctionArgument[]
+            {
+                new FunctionArgument(value1.ToString("n")),
+                new FunctionArgument(value2),
+                new FunctionArgument(value3.ToString("n")),
+                new FunctionArgument(true),
+                new FunctionArgument(date1),
+                new FunctionArgument(date2.ToString("d"))
+            }, ParsingContext.Create());
+            Assert.AreEqual((value1 + value2 + value3 + value4 + value5 + value6) / 6, result.Result);
+        }
 
-		[TestMethod]
-		public void AverageCellReferences()
-		{
-			// In the case of cell references, Average DOES NOT parse and include numeric strings, date strings, bools, unparsable strings, etc.
-			ExcelPackage package = new ExcelPackage();
-			var worksheet = package.Workbook.Worksheets.Add("Test");
-			ExcelRange range1 = worksheet.Cells[1, 1];
-			range1.Formula = "\"1000\"";
-			range1.Calculate();
-			var range2 = worksheet.Cells[1, 2];
-			range2.Value = 2000;
-			var range3 = worksheet.Cells[1, 3];
-			range3.Formula = $"\"{new DateTime(2013, 1, 5).ToString("d")}\"";
-			range3.Calculate();
-			var range4 = worksheet.Cells[1, 4];
-			range4.Value = true;
-			var range5 = worksheet.Cells[1, 5];
-			range5.Value = new DateTime(2013, 1, 5);
-			var range6 = worksheet.Cells[1, 6];
-			range6.Value = "Test";
-			Average average = new Average();
-			var rangeInfo1 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 1, 1, 3);
-			var rangeInfo2 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 4, 1, 4);
-			var rangeInfo3 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 5, 1, 6);
-			var context = ParsingContext.Create();
-			var address = new OfficeOpenXml.FormulaParsing.ExcelUtilities.RangeAddress();
-			address.FromRow = address.ToRow = address.FromCol = address.ToCol = 2;
-			context.Scopes.NewScope(address);
-			var result = average.Execute(new FunctionArgument[]
-			{
-				new FunctionArgument(rangeInfo1),
-				new FunctionArgument(rangeInfo2),
-				new FunctionArgument(rangeInfo3)
-			}, context);
-			Assert.AreEqual((2000 + new DateTime(2013, 1, 5).ToOADate()) / 2, result.Result);
-		}
+        [TestMethod]
+        public void AverageCellReferences()
+        {
+            // In the case of cell references, Average DOES NOT parse and include numeric strings, date strings, bools, unparsable strings, etc.
+            ExcelPackage package = new ExcelPackage();
+            var worksheet = package.Workbook.Worksheets.Add("Test");
+            ExcelRange range1 = worksheet.Cells[1, 1];
+            range1.Formula = "\"1000\"";
+            range1.Calculate();
+            var range2 = worksheet.Cells[1, 2];
+            range2.Value = 2000;
+            var range3 = worksheet.Cells[1, 3];
+            range3.Formula = $"\"{new DateTime(2013, 1, 5).ToString("d")}\"";
+            range3.Calculate();
+            var range4 = worksheet.Cells[1, 4];
+            range4.Value = true;
+            var range5 = worksheet.Cells[1, 5];
+            range5.Value = new DateTime(2013, 1, 5);
+            var range6 = worksheet.Cells[1, 6];
+            range6.Value = "Test";
+            Average average = new Average();
+            var rangeInfo1 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 1, 1, 3);
+            var rangeInfo2 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 4, 1, 4);
+            var rangeInfo3 = new EpplusExcelDataProvider.RangeInfo(worksheet, 1, 5, 1, 6);
+            var context = ParsingContext.Create();
+            var address = new OfficeOpenXml.FormulaParsing.ExcelUtilities.RangeAddress();
+            address.FromRow = address.ToRow = address.FromCol = address.ToCol = 2;
+            context.Scopes.NewScope(address);
+            var result = average.Execute(new FunctionArgument[]
+            {
+                new FunctionArgument(rangeInfo1),
+                new FunctionArgument(rangeInfo2),
+                new FunctionArgument(rangeInfo3)
+            }, context);
+            Assert.AreEqual((2000 + new DateTime(2013, 1, 5).ToOADate()) / 2, result.Result);
+        }
 
-		[TestMethod]
-		public void AverageArray()
-		{
-			// In the case of arrays, Average DOES NOT parse and include numeric strings, date strings, bools, unparsable strings, etc.
-			Average average = new Average();
-			var date1 = new DateTime(2013, 1, 5);
-			var date2 = new DateTime(2013, 1, 15);
-			double value = 2000;
-			var result = average.Execute(new FunctionArgument[]
-			{
-				new FunctionArgument(new FunctionArgument[]
-				{
-					new FunctionArgument(1000.ToString("n")),
-					new FunctionArgument(value),
-					new FunctionArgument(6000.ToString("n")),
-					new FunctionArgument(true),
-					new FunctionArgument(date1),
-					new FunctionArgument(date2.ToString("d")),
-					new FunctionArgument("test")
-				})
-			}, ParsingContext.Create());
-			Assert.AreEqual((2000 + date1.ToOADate()) / 2, result.Result);
-		}
+        [TestMethod]
+        public void AverageArray()
+        {
+            // In the case of arrays, Average DOES NOT parse and include numeric strings, date strings, bools, unparsable strings, etc.
+            Average average = new Average();
+            var date1 = new DateTime(2013, 1, 5);
+            var date2 = new DateTime(2013, 1, 15);
+            double value = 2000;
+            var result = average.Execute(new FunctionArgument[]
+            {
+                new FunctionArgument(new FunctionArgument[]
+                {
+                    new FunctionArgument(1000.ToString("n")),
+                    new FunctionArgument(value),
+                    new FunctionArgument(6000.ToString("n")),
+                    new FunctionArgument(true),
+                    new FunctionArgument(date1),
+                    new FunctionArgument(date2.ToString("d")),
+                    new FunctionArgument("test")
+                })
+            }, ParsingContext.Create());
+            Assert.AreEqual((2000 + date1.ToOADate()) / 2, result.Result);
+        }
 
-		[TestMethod]
-		[ExpectedException(typeof(ExcelErrorValueException))]
-		public void AverageUnparsableLiteral()
-		{
-			// In the case of literals, any unparsable string literal results in a #VALUE.
-			Average average = new Average();
-			var result = average.Execute(new FunctionArgument[]
-			{
-				new FunctionArgument(1000),
-				new FunctionArgument("Test")
-			}, ParsingContext.Create());
-		}
-	}
+        [TestMethod]
+        [ExpectedException(typeof(ExcelErrorValueException))]
+        public void AverageUnparsableLiteral()
+        {
+            // In the case of literals, any unparsable string literal results in a #VALUE.
+            Average average = new Average();
+            var result = average.Execute(new FunctionArgument[]
+            {
+                new FunctionArgument(1000),
+                new FunctionArgument("Test")
+            }, ParsingContext.Create());
+        }
+    }
 }

--- a/EPPlusTest/FormulaParsing/Excel/Functions/Math/RoundTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/Math/RoundTests.cs
@@ -9,22 +9,22 @@ using OfficeOpenXml.FormulaParsing.Exceptions;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.Math
 {
-	[TestClass]
-	public class RoundTests
-	{
-		[TestMethod]
-		public void RoundPositiveToOnesDownLiteral()
-		{
-			Round round = new Round();
-			double value1 = 123.45;
-		    int digits = 0;
-			var result = round.Execute(new FunctionArgument[]
-			{
-				new FunctionArgument(value1),
-				new FunctionArgument(digits)
-			}, ParsingContext.Create());
-			Assert.AreEqual(123D, result.Result);
-		}
+    [TestClass]
+    public class RoundTests
+    {
+        [TestMethod]
+        public void RoundPositiveToOnesDownLiteral()
+        {
+            Round round = new Round();
+            double value1 = 123.45;
+            int digits = 0;
+            var result = round.Execute(new FunctionArgument[]
+            {
+                new FunctionArgument(value1),
+                new FunctionArgument(digits)
+            }, ParsingContext.Create());
+            Assert.AreEqual(123D, result.Result);
+        }
         [TestMethod]
         public void RoundPositiveToOnesUpLiteral()
         {

--- a/EPPlusTest/FormulaParsing/Excel/OperatorsTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/OperatorsTests.cs
@@ -146,44 +146,44 @@ namespace EPPlusTest.Excel
         }
 
         [TestMethod]
-		public void OperatorsActingOnNumericStrings()
-		{
-			double number1 = 42.0;
-			double number2 = -143.75;
-			CompileResult result1 = new CompileResult(number1.ToString("n"), DataType.String);
-			CompileResult result2 = new CompileResult(number2.ToString("n"), DataType.String);
-			var operatorResult = Operator.Concat.Apply(result1, result2);
-			Assert.AreEqual($"{number1.ToString("n")}{number2.ToString("n")}", operatorResult.Result);
-			operatorResult = Operator.Divide.Apply(result1, result2);
-			Assert.AreEqual(number1 / number2, operatorResult.Result);
-			operatorResult = Operator.Exp.Apply(result1, result2);
-			Assert.AreEqual(Math.Pow(number1, number2), operatorResult.Result);
-			operatorResult = Operator.Minus.Apply(result1, result2);
-			Assert.AreEqual(number1 - number2, operatorResult.Result);
-			operatorResult = Operator.Multiply.Apply(result1, result2);
-			Assert.AreEqual(number1 * number2, operatorResult.Result);
-			operatorResult = Operator.Percent.Apply(result1, result2);
-			Assert.AreEqual(number1 * number2, operatorResult.Result);
-			operatorResult = Operator.Plus.Apply(result1, result2);
-			Assert.AreEqual(number1 + number2, operatorResult.Result);
-			// Comparison operators always compare string-wise and don't parse out the actual numbers.
-			operatorResult = Operator.NotEqualsTo.Apply(result1, new CompileResult(number1.ToString("n0"), DataType.String));
-			Assert.IsTrue((bool)operatorResult.Result);
-			operatorResult = Operator.Eq.Apply(result1, new CompileResult(number1.ToString("n0"), DataType.String));
-			Assert.IsFalse((bool)operatorResult.Result);
-			operatorResult = Operator.GreaterThan.Apply(result1, result2);
-			Assert.IsTrue((bool)operatorResult.Result);
-			operatorResult = Operator.GreaterThanOrEqual.Apply(result1, result2);
-			Assert.IsTrue((bool)operatorResult.Result);
-			operatorResult = Operator.LessThan.Apply(result1, result2);
-			Assert.IsFalse((bool)operatorResult.Result);
-			operatorResult = Operator.LessThanOrEqual.Apply(result1, result2);
-			Assert.IsFalse((bool)operatorResult.Result);
-		}
+        public void OperatorsActingOnNumericStrings()
+        {
+            double number1 = 42.0;
+            double number2 = -143.75;
+            CompileResult result1 = new CompileResult(number1.ToString("n"), DataType.String);
+            CompileResult result2 = new CompileResult(number2.ToString("n"), DataType.String);
+            var operatorResult = Operator.Concat.Apply(result1, result2);
+            Assert.AreEqual($"{number1.ToString("n")}{number2.ToString("n")}", operatorResult.Result);
+            operatorResult = Operator.Divide.Apply(result1, result2);
+            Assert.AreEqual(number1 / number2, operatorResult.Result);
+            operatorResult = Operator.Exp.Apply(result1, result2);
+            Assert.AreEqual(Math.Pow(number1, number2), operatorResult.Result);
+            operatorResult = Operator.Minus.Apply(result1, result2);
+            Assert.AreEqual(number1 - number2, operatorResult.Result);
+            operatorResult = Operator.Multiply.Apply(result1, result2);
+            Assert.AreEqual(number1 * number2, operatorResult.Result);
+            operatorResult = Operator.Percent.Apply(result1, result2);
+            Assert.AreEqual(number1 * number2, operatorResult.Result);
+            operatorResult = Operator.Plus.Apply(result1, result2);
+            Assert.AreEqual(number1 + number2, operatorResult.Result);
+            // Comparison operators always compare string-wise and don't parse out the actual numbers.
+            operatorResult = Operator.NotEqualsTo.Apply(result1, new CompileResult(number1.ToString("n0"), DataType.String));
+            Assert.IsTrue((bool)operatorResult.Result);
+            operatorResult = Operator.Eq.Apply(result1, new CompileResult(number1.ToString("n0"), DataType.String));
+            Assert.IsFalse((bool)operatorResult.Result);
+            operatorResult = Operator.GreaterThan.Apply(result1, result2);
+            Assert.IsTrue((bool)operatorResult.Result);
+            operatorResult = Operator.GreaterThanOrEqual.Apply(result1, result2);
+            Assert.IsTrue((bool)operatorResult.Result);
+            operatorResult = Operator.LessThan.Apply(result1, result2);
+            Assert.IsFalse((bool)operatorResult.Result);
+            operatorResult = Operator.LessThanOrEqual.Apply(result1, result2);
+            Assert.IsFalse((bool)operatorResult.Result);
+        }
 
-		[TestMethod]
-		public void OperatorsActingOnDateStrings()
-		{
+        [TestMethod]
+        public void OperatorsActingOnDateStrings()
+        {
             const string dateFormat = "M-dd-yyyy";
             DateTime date1 = new DateTime(2015, 2, 20);
             DateTime date2 = new DateTime(2015, 12, 1);
@@ -198,26 +198,26 @@ namespace EPPlusTest.Excel
             operatorResult = Operator.Exp.Apply(result1, result2);
             Assert.AreEqual(Math.Pow(numericDate1, numericDate2), operatorResult.Result);
             operatorResult = Operator.Minus.Apply(result1, result2);
-			Assert.AreEqual(numericDate1 - numericDate2, operatorResult.Result);
-			operatorResult = Operator.Multiply.Apply(result1, result2);
-			Assert.AreEqual(numericDate1 * numericDate2, operatorResult.Result);
-			operatorResult = Operator.Percent.Apply(result1, result2);
-			Assert.AreEqual(numericDate1 * numericDate2, operatorResult.Result);
-			operatorResult = Operator.Plus.Apply(result1, result2);
-			Assert.AreEqual(numericDate1 + numericDate2, operatorResult.Result);
-			// Comparison operators always compare string-wise and don't parse out the actual numbers.
-			operatorResult = Operator.Eq.Apply(result1, new CompileResult(date1.ToString("f"), DataType.String));
-			Assert.IsFalse((bool)operatorResult.Result);
-			operatorResult = Operator.NotEqualsTo.Apply(result1, new CompileResult(date1.ToString("f"), DataType.String));
-			Assert.IsTrue((bool)operatorResult.Result);
-			operatorResult = Operator.GreaterThan.Apply(result1, result2);
-			Assert.IsTrue((bool)operatorResult.Result);
-			operatorResult = Operator.GreaterThanOrEqual.Apply(result1, result2);
-			Assert.IsTrue((bool)operatorResult.Result);
-			operatorResult = Operator.LessThan.Apply(result1, result2);
-			Assert.IsFalse((bool)operatorResult.Result);
-			operatorResult = Operator.LessThanOrEqual.Apply(result1, result2);
-			Assert.IsFalse((bool)operatorResult.Result);
-		}
-	}
+            Assert.AreEqual(numericDate1 - numericDate2, operatorResult.Result);
+            operatorResult = Operator.Multiply.Apply(result1, result2);
+            Assert.AreEqual(numericDate1 * numericDate2, operatorResult.Result);
+            operatorResult = Operator.Percent.Apply(result1, result2);
+            Assert.AreEqual(numericDate1 * numericDate2, operatorResult.Result);
+            operatorResult = Operator.Plus.Apply(result1, result2);
+            Assert.AreEqual(numericDate1 + numericDate2, operatorResult.Result);
+            // Comparison operators always compare string-wise and don't parse out the actual numbers.
+            operatorResult = Operator.Eq.Apply(result1, new CompileResult(date1.ToString("f"), DataType.String));
+            Assert.IsFalse((bool)operatorResult.Result);
+            operatorResult = Operator.NotEqualsTo.Apply(result1, new CompileResult(date1.ToString("f"), DataType.String));
+            Assert.IsTrue((bool)operatorResult.Result);
+            operatorResult = Operator.GreaterThan.Apply(result1, result2);
+            Assert.IsTrue((bool)operatorResult.Result);
+            operatorResult = Operator.GreaterThanOrEqual.Apply(result1, result2);
+            Assert.IsTrue((bool)operatorResult.Result);
+            operatorResult = Operator.LessThan.Apply(result1, result2);
+            Assert.IsFalse((bool)operatorResult.Result);
+            operatorResult = Operator.LessThanOrEqual.Apply(result1, result2);
+            Assert.IsFalse((bool)operatorResult.Result);
+        }
+    }
 }

--- a/EPPlusTest/FormulaParsing/ExpressionGraph/CompileResultTests.cs
+++ b/EPPlusTest/FormulaParsing/ExpressionGraph/CompileResultTests.cs
@@ -4,29 +4,29 @@ using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 
 namespace EPPlusTest.FormulaParsing.ExpressionGraph
 {
-	[TestClass]
-	public class CompileResultTests
-	{
-		[TestMethod]
-		public void NumericStringCompileResult()
-		{
-			var expected = 124.24;
-			string numericString = expected.ToString("n");
-			CompileResult result = new CompileResult(numericString, DataType.String);
-			Assert.IsFalse(result.IsNumeric);
-			Assert.IsTrue(result.IsNumericString);
-			Assert.AreEqual(expected, result.ResultNumeric);
-		}
+    [TestClass]
+    public class CompileResultTests
+    {
+        [TestMethod]
+        public void NumericStringCompileResult()
+        {
+            var expected = 124.24;
+            string numericString = expected.ToString("n");
+            CompileResult result = new CompileResult(numericString, DataType.String);
+            Assert.IsFalse(result.IsNumeric);
+            Assert.IsTrue(result.IsNumericString);
+            Assert.AreEqual(expected, result.ResultNumeric);
+        }
 
-		[TestMethod]
-		public void DateStringCompileResult()
-		{
-			var expected = new DateTime(2013, 1, 15);
-			string dateString = expected.ToString("d");
-			CompileResult result = new CompileResult(dateString, DataType.String);
-			Assert.IsFalse(result.IsNumeric);
-			Assert.IsTrue(result.IsDateString);
-			Assert.AreEqual(expected.ToOADate(), result.ResultNumeric);
-		}
-	}
+        [TestMethod]
+        public void DateStringCompileResult()
+        {
+            var expected = new DateTime(2013, 1, 15);
+            string dateString = expected.ToString("d");
+            CompileResult result = new CompileResult(dateString, DataType.String);
+            Assert.IsFalse(result.IsNumeric);
+            Assert.IsTrue(result.IsDateString);
+            Assert.AreEqual(expected.ToOADate(), result.ResultNumeric);
+        }
+    }
 }

--- a/EPPlusTest/Issues.cs
+++ b/EPPlusTest/Issues.cs
@@ -2209,8 +2209,8 @@ namespace EPPlusTest
             {
                 return new List<Car>
             {
-				//random data
-				new Car(1,"Toyota", "Carolla", 1950),
+                //random data
+                new Car(1,"Toyota", "Carolla", 1950),
                 new Car(2,"Toyota", "Yaris", 2000),
                 new Car(3,"Toyota", "Hilux", 1990),
                 new Car(4,"Nissan", "Juke", 2010),

--- a/EPPlusTest/Utils/ConvertUtilTest.cs
+++ b/EPPlusTest/Utils/ConvertUtilTest.cs
@@ -7,74 +7,74 @@ using OfficeOpenXml.Compatibility;
 
 namespace EPPlusTest.Utils
 {
-	[TestClass]
-	public class ConvertUtilTest
-	{
-		[TestMethod]
-		public void TryParseNumericString()
-		{
-			double result;
-			object numericString = null;
-			double expected = 0;
-			Assert.IsFalse(ConvertUtil.TryParseNumericString(numericString, out result));
-			Assert.AreEqual(expected, result);
-			expected = 1442.0;
-			numericString = expected.ToString("e", CultureInfo.CurrentCulture); // 1.442E+003
-			Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
-			Assert.AreEqual(expected, result);
-			numericString = expected.ToString("f0", CultureInfo.CurrentCulture); // 1442
-			Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
-			Assert.AreEqual(expected, result);
-			numericString = expected.ToString("f2", CultureInfo.CurrentCulture); // 1442.00
-			Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
-			Assert.AreEqual(expected, result);
-			numericString = expected.ToString("n", CultureInfo.CurrentCulture); // 1,442.0
-			Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
-			Assert.AreEqual(expected, result);
-			expected = -0.00526;
-			numericString = expected.ToString("e", CultureInfo.CurrentCulture); // -5.26E-003
-			Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
-			Assert.AreEqual(expected, result);
-			numericString = expected.ToString("f0", CultureInfo.CurrentCulture); // -0
-			Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
-			Assert.AreEqual(0.0, result);
-			numericString = expected.ToString("f3", CultureInfo.CurrentCulture); // -0.005
-			Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
-			Assert.AreEqual(-0.005, result);
-			numericString = expected.ToString("n6", CultureInfo.CurrentCulture); // -0.005260
-			Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
-			Assert.AreEqual(expected, result);
-		}
-		
-		[TestMethod]
-		public void TryParseDateString()
-		{
-			DateTime result;
-			object dateString = null;
-			DateTime expected = DateTime.MinValue;
-			Assert.IsFalse(ConvertUtil.TryParseDateString(dateString, out result));
-			Assert.AreEqual(expected, result);
-			expected = new DateTime(2013, 1, 15);
-			dateString = expected.ToString("d", CultureInfo.CurrentCulture); // 1/15/2013
-			Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
-			Assert.AreEqual(expected, result);
-			dateString = expected.ToString("D", CultureInfo.CurrentCulture); // Tuesday, January 15, 2013
-			Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
-			Assert.AreEqual(expected, result);
-			dateString = expected.ToString("F", CultureInfo.CurrentCulture); // Tuesday, January 15, 2013 12:00:00 AM
-			Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
-			Assert.AreEqual(expected, result);
-			dateString = expected.ToString("g", CultureInfo.CurrentCulture); // 1/15/2013 12:00 AM
-			Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
-			Assert.AreEqual(expected, result);
-			expected = new DateTime(2013, 1, 15, 15, 26, 32);
-			dateString = expected.ToString("F", CultureInfo.CurrentCulture); // Tuesday, January 15, 2013 3:26:32 PM
-			Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
-			Assert.AreEqual(expected, result);
-			dateString = expected.ToString("g", CultureInfo.CurrentCulture); // 1/15/2013 3:26 PM
-			Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
-			Assert.AreEqual(new DateTime(2013, 1, 15, 15, 26, 0), result);
-		}
+    [TestClass]
+    public class ConvertUtilTest
+    {
+        [TestMethod]
+        public void TryParseNumericString()
+        {
+            double result;
+            object numericString = null;
+            double expected = 0;
+            Assert.IsFalse(ConvertUtil.TryParseNumericString(numericString, out result));
+            Assert.AreEqual(expected, result);
+            expected = 1442.0;
+            numericString = expected.ToString("e", CultureInfo.CurrentCulture); // 1.442E+003
+            Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
+            Assert.AreEqual(expected, result);
+            numericString = expected.ToString("f0", CultureInfo.CurrentCulture); // 1442
+            Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
+            Assert.AreEqual(expected, result);
+            numericString = expected.ToString("f2", CultureInfo.CurrentCulture); // 1442.00
+            Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
+            Assert.AreEqual(expected, result);
+            numericString = expected.ToString("n", CultureInfo.CurrentCulture); // 1,442.0
+            Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
+            Assert.AreEqual(expected, result);
+            expected = -0.00526;
+            numericString = expected.ToString("e", CultureInfo.CurrentCulture); // -5.26E-003
+            Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
+            Assert.AreEqual(expected, result);
+            numericString = expected.ToString("f0", CultureInfo.CurrentCulture); // -0
+            Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
+            Assert.AreEqual(0.0, result);
+            numericString = expected.ToString("f3", CultureInfo.CurrentCulture); // -0.005
+            Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
+            Assert.AreEqual(-0.005, result);
+            numericString = expected.ToString("n6", CultureInfo.CurrentCulture); // -0.005260
+            Assert.IsTrue(ConvertUtil.TryParseNumericString(numericString, out result));
+            Assert.AreEqual(expected, result);
+        }
+        
+        [TestMethod]
+        public void TryParseDateString()
+        {
+            DateTime result;
+            object dateString = null;
+            DateTime expected = DateTime.MinValue;
+            Assert.IsFalse(ConvertUtil.TryParseDateString(dateString, out result));
+            Assert.AreEqual(expected, result);
+            expected = new DateTime(2013, 1, 15);
+            dateString = expected.ToString("d", CultureInfo.CurrentCulture); // 1/15/2013
+            Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
+            Assert.AreEqual(expected, result);
+            dateString = expected.ToString("D", CultureInfo.CurrentCulture); // Tuesday, January 15, 2013
+            Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
+            Assert.AreEqual(expected, result);
+            dateString = expected.ToString("F", CultureInfo.CurrentCulture); // Tuesday, January 15, 2013 12:00:00 AM
+            Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
+            Assert.AreEqual(expected, result);
+            dateString = expected.ToString("g", CultureInfo.CurrentCulture); // 1/15/2013 12:00 AM
+            Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
+            Assert.AreEqual(expected, result);
+            expected = new DateTime(2013, 1, 15, 15, 26, 32);
+            dateString = expected.ToString("F", CultureInfo.CurrentCulture); // Tuesday, January 15, 2013 3:26:32 PM
+            Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
+            Assert.AreEqual(expected, result);
+            dateString = expected.ToString("g", CultureInfo.CurrentCulture); // 1/15/2013 3:26 PM
+            Assert.IsTrue(ConvertUtil.TryParseDateString(dateString, out result));
+            Assert.AreEqual(new DateTime(2013, 1, 15, 15, 26, 0), result);
+        }
 
         [TestMethod]
         public void TextToInt()

--- a/EPPlusTest/WorksheetsTests.cs
+++ b/EPPlusTest/WorksheetsTests.cs
@@ -6,100 +6,100 @@ using System.Reflection;
 
 namespace EPPlusTest
 {
-	[TestClass]
-	public class WorksheetsTests
-	{
-		private ExcelPackage package;
-		private ExcelWorkbook workbook;
+    [TestClass]
+    public class WorksheetsTests
+    {
+        private ExcelPackage package;
+        private ExcelWorkbook workbook;
 
-		[TestInitialize]
-		public void TestInitialize()
-		{
-			package = new ExcelPackage();
-			workbook = package.Workbook;
-			workbook.Worksheets.Add("NEW1");
-		}
-
-		[TestMethod]
-		public void ConfirmFileStructure()
-		{
-			Assert.IsNotNull(package, "Package not created");
-			Assert.IsNotNull(workbook, "No workbook found");
-		}
-
-		[TestMethod]
-		public void ShouldBeAbleToDeleteAndThenAdd()
-		{
-			workbook.Worksheets.Add("NEW2");
-			workbook.Worksheets.Delete(1);
-			workbook.Worksheets.Add("NEW3");
-		}
-
-		[TestMethod]
-		public void DeleteByNameWhereWorkSheetExists()
-		{
-		    workbook.Worksheets.Add("NEW2");
-			workbook.Worksheets.Delete("NEW2");
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            package = new ExcelPackage();
+            workbook = package.Workbook;
+            workbook.Worksheets.Add("NEW1");
         }
 
-		[TestMethod, ExpectedException(typeof(ArgumentException))]
-		public void DeleteByNameWhereWorkSheetDoesNotExist()
-		{
-			workbook.Worksheets.Add("NEW2");
-			workbook.Worksheets.Delete("NEW3");
-		}
+        [TestMethod]
+        public void ConfirmFileStructure()
+        {
+            Assert.IsNotNull(package, "Package not created");
+            Assert.IsNotNull(workbook, "No workbook found");
+        }
 
-		[TestMethod]
-		public void MoveBeforeByNameWhereWorkSheetExists()
-		{
-			workbook.Worksheets.Add("NEW2");
-			workbook.Worksheets.Add("NEW3");
-			workbook.Worksheets.Add("NEW4");
-			workbook.Worksheets.Add("NEW5");
+        [TestMethod]
+        public void ShouldBeAbleToDeleteAndThenAdd()
+        {
+            workbook.Worksheets.Add("NEW2");
+            workbook.Worksheets.Delete(1);
+            workbook.Worksheets.Add("NEW3");
+        }
 
-			workbook.Worksheets.MoveBefore("NEW4", "NEW2");
+        [TestMethod]
+        public void DeleteByNameWhereWorkSheetExists()
+        {
+            workbook.Worksheets.Add("NEW2");
+            workbook.Worksheets.Delete("NEW2");
+        }
 
-			CompareOrderOfWorksheetsAfterSaving(package);
-		}
+        [TestMethod, ExpectedException(typeof(ArgumentException))]
+        public void DeleteByNameWhereWorkSheetDoesNotExist()
+        {
+            workbook.Worksheets.Add("NEW2");
+            workbook.Worksheets.Delete("NEW3");
+        }
 
-		[TestMethod]
-		public void MoveAfterByNameWhereWorkSheetExists()
-		{
-			workbook.Worksheets.Add("NEW2");
-			workbook.Worksheets.Add("NEW3");
-			workbook.Worksheets.Add("NEW4");
-			workbook.Worksheets.Add("NEW5");
+        [TestMethod]
+        public void MoveBeforeByNameWhereWorkSheetExists()
+        {
+            workbook.Worksheets.Add("NEW2");
+            workbook.Worksheets.Add("NEW3");
+            workbook.Worksheets.Add("NEW4");
+            workbook.Worksheets.Add("NEW5");
 
-			workbook.Worksheets.MoveAfter("NEW4", "NEW2");
+            workbook.Worksheets.MoveBefore("NEW4", "NEW2");
 
-			CompareOrderOfWorksheetsAfterSaving(package);
-		}
+            CompareOrderOfWorksheetsAfterSaving(package);
+        }
 
-		[TestMethod]
-		public void MoveBeforeByPositionWhereWorkSheetExists()
-		{
-			workbook.Worksheets.Add("NEW2");
-			workbook.Worksheets.Add("NEW3");
-			workbook.Worksheets.Add("NEW4");
-			workbook.Worksheets.Add("NEW5");
+        [TestMethod]
+        public void MoveAfterByNameWhereWorkSheetExists()
+        {
+            workbook.Worksheets.Add("NEW2");
+            workbook.Worksheets.Add("NEW3");
+            workbook.Worksheets.Add("NEW4");
+            workbook.Worksheets.Add("NEW5");
 
-			workbook.Worksheets.MoveBefore(4, 2);
+            workbook.Worksheets.MoveAfter("NEW4", "NEW2");
 
-			CompareOrderOfWorksheetsAfterSaving(package);
-		}
+            CompareOrderOfWorksheetsAfterSaving(package);
+        }
 
-		[TestMethod]
-		public void MoveAfterByPositionWhereWorkSheetExists()
-		{
-			workbook.Worksheets.Add("NEW2");
-			workbook.Worksheets.Add("NEW3");
-			workbook.Worksheets.Add("NEW4");
-			workbook.Worksheets.Add("NEW5");
+        [TestMethod]
+        public void MoveBeforeByPositionWhereWorkSheetExists()
+        {
+            workbook.Worksheets.Add("NEW2");
+            workbook.Worksheets.Add("NEW3");
+            workbook.Worksheets.Add("NEW4");
+            workbook.Worksheets.Add("NEW5");
 
-			workbook.Worksheets.MoveAfter(4, 2);
+            workbook.Worksheets.MoveBefore(4, 2);
 
-			CompareOrderOfWorksheetsAfterSaving(package);
-		}
+            CompareOrderOfWorksheetsAfterSaving(package);
+        }
+
+        [TestMethod]
+        public void MoveAfterByPositionWhereWorkSheetExists()
+        {
+            workbook.Worksheets.Add("NEW2");
+            workbook.Worksheets.Add("NEW3");
+            workbook.Worksheets.Add("NEW4");
+            workbook.Worksheets.Add("NEW5");
+
+            workbook.Worksheets.MoveAfter(4, 2);
+
+            CompareOrderOfWorksheetsAfterSaving(package);
+        }
         #region Delete Column with Save Tests
 
         private const string OutputDirectory = @"d:\temp\";
@@ -259,18 +259,18 @@ namespace EPPlusTest
         }
 
         private static void CompareOrderOfWorksheetsAfterSaving(ExcelPackage editedPackage)
-		{
-			var packageStream = new MemoryStream();
-			editedPackage.SaveAs(packageStream);
+        {
+            var packageStream = new MemoryStream();
+            editedPackage.SaveAs(packageStream);
 
-			var newPackage = new ExcelPackage(packageStream);
+            var newPackage = new ExcelPackage(packageStream);
             newPackage.Compatibility.IsWorksheets1Based = true;
             var positionId = 1;
-			foreach (var worksheet in editedPackage.Workbook.Worksheets)
-			{
-				Assert.AreEqual(worksheet.Name, newPackage.Workbook.Worksheets[positionId].Name, "Worksheets are not in the same order");
-				positionId++;
-			}
-		}
-	}
+            foreach (var worksheet in editedPackage.Workbook.Worksheets)
+            {
+                Assert.AreEqual(worksheet.Name, newPackage.Workbook.Worksheets[positionId].Name, "Worksheets are not in the same order");
+                positionId++;
+            }
+        }
+    }
 }

--- a/SampleApp.Core/Sample1.cs
+++ b/SampleApp.Core/Sample1.cs
@@ -39,15 +39,15 @@ using System.Drawing;
 using OfficeOpenXml.Style;
 namespace EPPlusSamples
 {
-	class Sample1
-	{
+    class Sample1
+    {
         /// <summary>
         /// Sample 1 - simply creates a new workbook from scratch.
         /// The workbook contains one worksheet with a simple invertory list
         /// </summary>
         public static string RunSample1()
         {
-			using (var package = new ExcelPackage())
+            using (var package = new ExcelPackage())
             {
                 // Add a new worksheet to the empty workbook
                 ExcelWorksheet worksheet = package.Workbook.Worksheets.Add("Inventory");
@@ -138,6 +138,6 @@ namespace EPPlusSamples
                 package.SaveAs(xlFile);
                 return xlFile.FullName;
             }
-		}
-	}
+        }
+    }
 }

--- a/SampleApp.Core/Sample2.cs
+++ b/SampleApp.Core/Sample2.cs
@@ -37,28 +37,28 @@ using OfficeOpenXml;
 
 namespace EPPlusSamples
 {
-	/// <summary>
-	/// Simply opens an existing file and reads some values and properties
-	/// </summary>
-	class Sample2
-	{
-		public static void RunSample2(string FilePath)
-		{
-			Console.WriteLine("Reading column 2 of {0}", FilePath);
-			Console.WriteLine();
+    /// <summary>
+    /// Simply opens an existing file and reads some values and properties
+    /// </summary>
+    class Sample2
+    {
+        public static void RunSample2(string FilePath)
+        {
+            Console.WriteLine("Reading column 2 of {0}", FilePath);
+            Console.WriteLine();
 
-			FileInfo existingFile = new FileInfo(FilePath);
-			using (ExcelPackage package = new ExcelPackage(existingFile))
-			{
+            FileInfo existingFile = new FileInfo(FilePath);
+            using (ExcelPackage package = new ExcelPackage(existingFile))
+            {
                 // get the first worksheet in the workbook
                 ExcelWorksheet worksheet = package.Workbook.Worksheets[0];
                 int col = 2; //The item description
-				// output the data in column 2
-				for (int row = 2; row < 5; row++)
-					Console.WriteLine("\tCell({0},{1}).Value={2}", row, col, worksheet.Cells[row, col].Value);
+                // output the data in column 2
+                for (int row = 2; row < 5; row++)
+                    Console.WriteLine("\tCell({0},{1}).Value={2}", row, col, worksheet.Cells[row, col].Value);
 
-				// output the formula in row 5
-				Console.WriteLine("\tCell({0},{1}).Formula={2}", 3, 5, worksheet.Cells[3, 5].Formula);                
+                // output the formula in row 5
+                Console.WriteLine("\tCell({0},{1}).Formula={2}", 3, 5, worksheet.Cells[3, 5].Formula);                
                 Console.WriteLine("\tCell({0},{1}).FormulaR1C1={2}", 3, 5, worksheet.Cells[3, 5].FormulaR1C1);
 
                 // output the formula in row 5
@@ -67,9 +67,9 @@ namespace EPPlusSamples
 
             } // the using statement automatically calls Dispose() which closes the package.
 
-			Console.WriteLine();
-			Console.WriteLine("Sample 2 complete");
-			Console.WriteLine();
-		}
-	}
+            Console.WriteLine();
+            Console.WriteLine("Sample 2 complete");
+            Console.WriteLine();
+        }
+    }
 }

--- a/SampleApp.Core/Sample3.cs
+++ b/SampleApp.Core/Sample3.cs
@@ -56,18 +56,18 @@ using OfficeOpenXml.Style;
 
 namespace EPPlusSamples
 {
-	class Sample3
-	{
-		/// <summary>
-		/// Sample 3 - creates a workbook and populates using data from the AdventureWorks database
-		/// This sample requires the AdventureWorks database.  
+    class Sample3
+    {
+        /// <summary>
+        /// Sample 3 - creates a workbook and populates using data from the AdventureWorks database
+        /// This sample requires the AdventureWorks database.  
         /// This one is from the orginal Excelpackage sample project, but without the template
-		/// </summary>
-		/// <param name="outputDir">The output directory</param>
-		/// <param name="templateDir">The location of the sample template</param>
-		/// <param name="connectionString">The connection string to your copy of the AdventureWorks database</param>
-		public static string RunSample3(string connectionString)
-		{
+        /// </summary>
+        /// <param name="outputDir">The output directory</param>
+        /// <param name="templateDir">The location of the sample template</param>
+        /// <param name="connectionString">The connection string to your copy of the AdventureWorks database</param>
+        public static string RunSample3(string connectionString)
+        {
             var file = Utils.GetFileInfo("Sample3.xlsx");
             // ok, we can run the real code of the sample now
             using (ExcelPackage xlPackage = new ExcelPackage(file))
@@ -202,7 +202,7 @@ namespace EPPlusSamples
                 xlPackage.Save();
             }
 
-			return file.FullName;
-		}
-	}
+            return file.FullName;
+        }
+    }
 }

--- a/SampleApp.Core/Sample8.cs
+++ b/SampleApp.Core/Sample8.cs
@@ -48,8 +48,8 @@ namespace EPPlusSamples
         /// <param name="outputDir">The path where sample7.xlsx is</param>
         public static void RunLinqSample()
         {
-	        Console.WriteLine("Now open sample 7 again and perform some Linq queries...");
-		    Console.WriteLine();
+            Console.WriteLine("Now open sample 7 again and perform some Linq queries...");
+            Console.WriteLine();
 
             FileInfo existingFile = Utils.GetFileInfo("sample7.xlsx", false);
             using (ExcelPackage package = new ExcelPackage(existingFile))

--- a/SampleApp.Core/Sample_Main.cs
+++ b/SampleApp.Core/Sample_Main.cs
@@ -36,12 +36,12 @@ using OfficeOpenXml;
 
 namespace EPPlusSamples
 {
-	class Sample_Main
-	{
-		static void Main(string[] args)
-		{
-			try
-			{
+    class Sample_Main
+    {
+        static void Main(string[] args)
+        {
+            try
+            {
                 //Sample 3, 4 and 12 uses the Adventureworks database. Enter the connectionstring to the Adventureworks database(2016 CTP3) into the variable below...
                 //Leave this blank if you don't have access to the Adventureworks database 
                 string connectionStr = "";      //for example "Integrated Security=SSPI;Persist Security Info=False;Initial Catalog=AdventureWorks2016CTP3;Data Source=MySqlServer"
@@ -171,18 +171,18 @@ namespace EPPlusSamples
                 Sample_AddFormulaFunction.RunSample_AddFormulaFunction();
                 Console.WriteLine();
             }
-			catch (Exception ex)
+            catch (Exception ex)
             {
                 Console.WriteLine("Error: {0}", ex.Message);
-			}
+            }
             var prevColor = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine($"Genereted sample workbooks can be found in {Utils.OutputDir.FullName}");
             Console.ForegroundColor = prevColor;
 
             Console.WriteLine();
-			Console.WriteLine("Press the return key to exit...");
-			Console.Read();
-		}
-	}
+            Console.WriteLine("Press the return key to exit...");
+            Console.Read();
+        }
+    }
 }

--- a/SampleApp/Sample1.cs
+++ b/SampleApp/Sample1.cs
@@ -39,15 +39,15 @@ using System.Drawing;
 using OfficeOpenXml.Style;
 namespace EPPlusSamples
 {
-	class Sample1
-	{
+    class Sample1
+    {
         /// <summary>
         /// Sample 1 - simply creates a new workbook from scratch.
         /// The workbook contains one worksheet with a simple invertory list
         /// </summary>
         public static string RunSample1()
         {
-			using (var package = new ExcelPackage())
+            using (var package = new ExcelPackage())
             {
                 // Add a new worksheet to the empty workbook
                 ExcelWorksheet worksheet = package.Workbook.Worksheets.Add("Inventory");
@@ -138,6 +138,6 @@ namespace EPPlusSamples
                 package.SaveAs(xlFile);
                 return xlFile.FullName;
             }
-		}
-	}
+        }
+    }
 }

--- a/SampleApp/Sample2.cs
+++ b/SampleApp/Sample2.cs
@@ -37,28 +37,28 @@ using OfficeOpenXml;
 
 namespace EPPlusSamples
 {
-	/// <summary>
-	/// Simply opens an existing file and reads some values and properties
-	/// </summary>
-	class Sample2
-	{
-		public static void RunSample2(string FilePath)
-		{
-			Console.WriteLine("Reading column 2 of {0}", FilePath);
-			Console.WriteLine();
+    /// <summary>
+    /// Simply opens an existing file and reads some values and properties
+    /// </summary>
+    class Sample2
+    {
+        public static void RunSample2(string FilePath)
+        {
+            Console.WriteLine("Reading column 2 of {0}", FilePath);
+            Console.WriteLine();
 
-			FileInfo existingFile = new FileInfo(FilePath);
-			using (ExcelPackage package = new ExcelPackage(existingFile))
-			{
+            FileInfo existingFile = new FileInfo(FilePath);
+            using (ExcelPackage package = new ExcelPackage(existingFile))
+            {
                 // get the first worksheet in the workbook
                 ExcelWorksheet worksheet = package.Workbook.Worksheets[1];
                 int col = 2; //The item description
-				// output the data in column 2
-				for (int row = 2; row < 5; row++)
-					Console.WriteLine("\tCell({0},{1}).Value={2}", row, col, worksheet.Cells[row, col].Value);
+                // output the data in column 2
+                for (int row = 2; row < 5; row++)
+                    Console.WriteLine("\tCell({0},{1}).Value={2}", row, col, worksheet.Cells[row, col].Value);
 
-				// output the formula in row 5
-				Console.WriteLine("\tCell({0},{1}).Formula={2}", 3, 5, worksheet.Cells[3, 5].Formula);                
+                // output the formula in row 5
+                Console.WriteLine("\tCell({0},{1}).Formula={2}", 3, 5, worksheet.Cells[3, 5].Formula);                
                 Console.WriteLine("\tCell({0},{1}).FormulaR1C1={2}", 3, 5, worksheet.Cells[3, 5].FormulaR1C1);
 
                 // output the formula in row 5
@@ -67,9 +67,9 @@ namespace EPPlusSamples
 
             } // the using statement automatically calls Dispose() which closes the package.
 
-			Console.WriteLine();
-			Console.WriteLine("Sample 2 complete");
-			Console.WriteLine();
-		}
-	}
+            Console.WriteLine();
+            Console.WriteLine("Sample 2 complete");
+            Console.WriteLine();
+        }
+    }
 }

--- a/SampleApp/Sample3.cs
+++ b/SampleApp/Sample3.cs
@@ -56,18 +56,18 @@ using OfficeOpenXml.Style;
 
 namespace EPPlusSamples
 {
-	class Sample3
-	{
-		/// <summary>
-		/// Sample 3 - creates a workbook and populates using data from the AdventureWorks database
-		/// This sample requires the AdventureWorks database.  
+    class Sample3
+    {
+        /// <summary>
+        /// Sample 3 - creates a workbook and populates using data from the AdventureWorks database
+        /// This sample requires the AdventureWorks database.  
         /// This one is from the orginal Excelpackage sample project, but without the template
-		/// </summary>
-		/// <param name="outputDir">The output directory</param>
-		/// <param name="templateDir">The location of the sample template</param>
-		/// <param name="connectionString">The connection string to your copy of the AdventureWorks database</param>
-		public static string RunSample3(string connectionString)
-		{
+        /// </summary>
+        /// <param name="outputDir">The output directory</param>
+        /// <param name="templateDir">The location of the sample template</param>
+        /// <param name="connectionString">The connection string to your copy of the AdventureWorks database</param>
+        public static string RunSample3(string connectionString)
+        {
             var file = Utils.GetFileInfo("Sample3.xlsx");
             // ok, we can run the real code of the sample now
             using (ExcelPackage xlPackage = new ExcelPackage(file))
@@ -202,7 +202,7 @@ namespace EPPlusSamples
                 xlPackage.Save();
             }
 
-			return file.FullName;
-		}
-	}
+            return file.FullName;
+        }
+    }
 }

--- a/SampleApp/Sample8.cs
+++ b/SampleApp/Sample8.cs
@@ -48,8 +48,8 @@ namespace EPPlusSamples
         /// <param name="outputDir">The path where sample7.xlsx is</param>
         public static void RunLinqSample()
         {
-	        Console.WriteLine("Now open sample 7 again and perform some Linq queries...");
-		    Console.WriteLine();
+            Console.WriteLine("Now open sample 7 again and perform some Linq queries...");
+            Console.WriteLine();
 
             FileInfo existingFile = Utils.GetFileInfo("sample7.xlsx", false);
             using (ExcelPackage package = new ExcelPackage(existingFile))

--- a/SampleApp/Sample_Main.cs
+++ b/SampleApp/Sample_Main.cs
@@ -36,12 +36,12 @@ using OfficeOpenXml;
 
 namespace EPPlusSamples
 {
-	class Sample_Main
-	{
-		static void Main(string[] args)
-		{
-			try
-			{
+    class Sample_Main
+    {
+        static void Main(string[] args)
+        {
+            try
+            {
                 //Sample 3, 4 and 12 uses the Adventureworks database. Enter the connectionstring to the Adventureworks database(2016 CTP3) into the variable below...
                 //Leave this blank if you don't have access to the Adventureworks database 
                 string connectionStr = "";      //for example "Integrated Security=SSPI;Persist Security Info=False;Initial Catalog=AdventureWorks2016CTP3;Data Source=MySqlServer"
@@ -171,10 +171,10 @@ namespace EPPlusSamples
                 Sample_AddFormulaFunction.RunSample_AddFormulaFunction();
                 Console.WriteLine();
             }
-			catch (Exception ex)
+            catch (Exception ex)
             {
                 Console.WriteLine("Error: {0}", ex.Message);
-			}
+            }
             var prevColor = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine($"Genereted sample workbooks can be found in {Utils.OutputDir.FullName}");
@@ -182,8 +182,8 @@ namespace EPPlusSamples
             Console.ForegroundColor = prevColor;
 
             Console.WriteLine();
-			Console.WriteLine("Press the return key to exit...");
-			Console.Read();
-		}
-	}
+            Console.WriteLine("Press the return key to exit...");
+            Console.Read();
+        }
+    }
 }


### PR DESCRIPTION
When viewing source files on the GitHub website, the inconsistent
use of tabs and spaces for indentation results in lines being
misaligned. The result is that it is harder to read and follow
code.

This change replaces all tabs in .cs files at the beginnings of lines
with 4 spaces. This seems to match the indentation convention currently
used by the authors and contributors.

Used command:

    find * -name '*.cs' -print0 | xargs -0 sed -i -e ':loop;s/^\( *\)\t/\1    /;tloop'

Fixes #303.

-[x] Write a detailed description of your what you have implemented or changed.

I used a script to replace any tabs at the beginning of `*.cs` files with four spaces each.

-[n/a] Attach unit tests in the testproject to test implemented functionallity.

Assuming `.editorconfig` (#304) is accepted, I will investigate seeing if it is feasible to set up CI to check that PRs respect the new rules.

-[x] Make sure no tests fail in the test project.

I did not set up the `C:\epplusTest` but I verified that the failure count (9) did not change after applying this patch.

-[x] Verify that you only check in the files intended for the pull request.
-[x] Do not change dotnet version, include new dependencies unless you explicitly talked to someone in the project about doing so.
