### PR TITLE
REPAIRED METHOD - internal ExcelBorderItemXml Copy()

### DIFF
--- a/EPPlus/Style/XmlAccess/ExcelBorderItemXml.cs
+++ b/EPPlus/Style/XmlAccess/ExcelBorderItemXml.cs
@@ -127,7 +127,10 @@ namespace OfficeOpenXml.Style.XmlAccess
         {
             ExcelBorderItemXml borderItem = new ExcelBorderItemXml(NameSpaceManager);
             borderItem.Style = _borderStyle;
-            borderItem.Color = _color.Copy();
+            if (_color != null)
+            {
+                borderItem.Color = _color.Copy();
+            }
             return borderItem;
         }
 


### PR DESCRIPTION
_color can be null in internal ExcelBorderItemXml Copy() and it causes NullReferenceException.
So my fix is to call _color.Copy() only when _color is not null