### PR TITLE
Fix: allow adding of rows/columns to entire row/column addresses

### DIFF
--- a/EPPlus/ExcelAddress.cs
+++ b/EPPlus/ExcelAddress.cs
@@ -724,7 +724,7 @@ namespace OfficeOpenXml
         }
         internal ExcelAddressBase AddRow(int row, int rows, bool setFixed=false)
         {
-            if (row > _toRow)
+            if (row > _toRow || _toRow == ExcelPackage.MaxRows)
             {
                 return this;
             }
@@ -739,7 +739,7 @@ namespace OfficeOpenXml
         }
         internal ExcelAddressBase DeleteRow(int row, int rows, bool setFixed = false)
         {
-            if (row > _toRow) //After
+            if (row > _toRow || _toRow == ExcelPackage.MaxRows) //After
             {
                 return this;
             }            
@@ -765,7 +765,7 @@ namespace OfficeOpenXml
         }
         internal ExcelAddressBase AddColumn(int col, int cols, bool setFixed = false)
         {
-            if (col > _toCol)
+            if (col > _toCol || _toCol == ExcelPackage.MaxColumns)
             {
                 return this;
             }
@@ -780,7 +780,7 @@ namespace OfficeOpenXml
         }
         internal ExcelAddressBase DeleteColumn(int col, int cols, bool setFixed = false)
         {
-            if (col > _toCol) //After
+            if (col > _toCol || _toCol == ExcelPackage.MaxColumns) //After
             {
                 return this;
             }


### PR DESCRIPTION
It can happen that you execute the following:

```
UpdateFormulaReferences("Sheet1!A:A", 0, 0, 1, 0, "Sheet1", "Sheet1");
```

or 

```
UpdateFormulaReferences("Sheet1!1:1", 3, 0, 0, 0, "Sheet1", "Sheet1");
```

The output of both methods will be an invalid formula: `#REF!`. However, I suggest that these actions should return the original formula. Because, if you add a row in an formula that has an entire row address, the row will be included by definition.

This PR adds a simple check to fix this bug.