### PR TITLE
Make address manipulation methods public

### DIFF
--- a/EPPlus/ExcelAddress.cs
+++ b/EPPlus/ExcelAddress.cs
@@ -362,7 +362,7 @@ namespace OfficeOpenXml
                 _address = address;
             }
         }
-        internal void ChangeWorksheet(string wsName, string newWs)
+        public void ChangeWorksheet(string wsName, string newWs)
         {
             if (_ws == wsName) _ws = newWs;
             var fullAddress = GetAddress();
@@ -528,7 +528,14 @@ namespace OfficeOpenXml
                 throw new ArgumentOutOfRangeException("Start cell Address must be less or equal to End cell address");
             }
         }
-        internal string WorkSheet
+        public string WorkBook
+        {
+            get
+            {
+                return _wb;
+            }
+        }
+        public string WorkSheet
         {
             get
             {
@@ -722,7 +729,7 @@ namespace OfficeOpenXml
             else
                 return eAddressCollition.Partly;
         }
-        internal ExcelAddressBase AddRow(int row, int rows, bool setFixed=false)
+        public ExcelAddressBase AddRow(int row, int rows, bool setFixed=false)
         {
             if (row > _toRow)
             {
@@ -737,7 +744,7 @@ namespace OfficeOpenXml
                 return new ExcelAddressBase(_fromRow, _fromCol, (setFixed && _toRowFixed ? _toRow : _toRow + rows), _toCol, _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed);
             }
         }
-        internal ExcelAddressBase DeleteRow(int row, int rows, bool setFixed = false)
+        public ExcelAddressBase DeleteRow(int row, int rows, bool setFixed = false)
         {
             if (row > _toRow) //After
             {
@@ -763,7 +770,7 @@ namespace OfficeOpenXml
                 }
             }
         }
-        internal ExcelAddressBase AddColumn(int col, int cols, bool setFixed = false)
+        public ExcelAddressBase AddColumn(int col, int cols, bool setFixed = false)
         {
             if (col > _toCol)
             {
@@ -778,7 +785,7 @@ namespace OfficeOpenXml
                 return new ExcelAddressBase(_fromRow, _fromCol, _toRow, (setFixed && _toColFixed ? _toCol : _toCol + cols), _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed);
             }
         }
-        internal ExcelAddressBase DeleteColumn(int col, int cols, bool setFixed = false)
+        public ExcelAddressBase DeleteColumn(int col, int cols, bool setFixed = false)
         {
             if (col > _toCol) //After
             {
@@ -1268,7 +1275,7 @@ namespace OfficeOpenXml
             return address.Substring(ix, endIx - ix).Replace("''","'");
         }
 
-        internal bool IsValidRowCol()
+        public bool IsValidRowCol()
         {
             return !(_fromRow > _toRow  ||
                    _fromCol > _toCol ||

--- a/EPPlus/ExcelCellBase.cs
+++ b/EPPlus/ExcelCellBase.cs
@@ -943,7 +943,7 @@ namespace OfficeOpenXml
         /// <param name="modifiedSheet">The sheet where cells are being inserted or deleted.</param>
         /// <param name="setFixed">Fixed address</param>
         /// <returns>The updated version of the <paramref name="formula"/>.</returns>
-        internal static string UpdateFormulaReferences(string formula, int rowIncrement, int colIncrement, int afterRow, int afterColumn, string currentSheet, string modifiedSheet, bool setFixed = false)
+        public static string UpdateFormulaReferences(string formula, int rowIncrement, int colIncrement, int afterRow, int afterColumn, string currentSheet, string modifiedSheet, bool setFixed = false)
         {
             var d = new Dictionary<string, object>();
             try
@@ -1021,7 +1021,7 @@ namespace OfficeOpenXml
         /// <param name="oldSheetName">The old sheet name.</param>
         /// <param name="newSheetName">The new sheet name.</param>
         /// <returns>The formula with all cross-sheet references updated.</returns>
-        internal static string UpdateFormulaSheetReferences(string formula, string oldSheetName, string newSheetName)
+        public static string UpdateFormulaSheetReferences(string formula, string oldSheetName, string newSheetName)
         {
           if (string.IsNullOrEmpty(oldSheetName))
             throw new ArgumentNullException(nameof(oldSheetName));


### PR DESCRIPTION
The EPPlus library has some useful methods for manipulation formulas. I use them directly to apply sheet name changes and row/column additions and deletions to formulas. The input is just a string, the output of the transformation should also be a string. It is not possible to call these methods directly in `ExcelAddress.cs` and `ExcelCellBase.cs`.

This PR makes the required methods public, and allows end-users to use the powerful formula logic built in EPPlus directly on formulas (as string). I hope you allow this, in practice the methods are very powerful!

Resolves #361.