### PR TITLE
Oplimized performance of data validation collection (Issue 151)

### DIFF
--- a/EPPlus/CellStore.cs
+++ b/EPPlus/CellStore.cs
@@ -1106,7 +1106,7 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
                 var delSize=page.MaxIndex - page.MinIndex+1;
                 rows -= delSize;
                 var prevOffset = page.Offset;
-                Array.Copy(column._pages, pagePos + 1, column._pages, pagePos, column.PageCount - pagePos + 1);
+                Array.Copy(column._pages, pagePos + 1, column._pages, pagePos, column.PageCount - pagePos);
                 column.PageCount--;
                 if (column.PageCount == 0)
                 {

--- a/EPPlus/CellStore.cs
+++ b/EPPlus/CellStore.cs
@@ -864,7 +864,7 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
                         var pagePos = column.GetPosition(fromRow);
                         if (pagePos >= 0)
                         {
-                            if (fromRow >= column._pages[pagePos].MinIndex && fromRow <= column._pages[pagePos].MaxIndex) //The row is inside the page
+                            if (IsWithinPage(fromRow, column, pagePos)) //The row is inside the page
                             {
                                 int offset = fromRow - column._pages[pagePos].IndexOffset;
                                 var rowPos = column._pages[pagePos].GetPosition(offset);
@@ -874,7 +874,7 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
                                 }
                                 UpdateIndexOffset(column, pagePos, rowPos, fromRow, rows);
                             }
-                            else if (column._pages[pagePos].MinIndex > fromRow - 1 && pagePos > 0) //The row is on the page before.
+                            else if (pagePos > 0 && IsWithinPage(fromRow, column, pagePos-1)) //The row is inside the previous page
                             {
                                 int offset = fromRow - ((page - 1) << pageBits);
                                 var rowPos = column._pages[pagePos - 1].GetPosition(offset);
@@ -909,7 +909,13 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
                 }
             }
         }
-        internal void Clear(int fromRow, int fromCol, int rows, int columns)
+
+    private static bool IsWithinPage(int row, ColumnIndex column, int pagePos)
+    {
+        return (row >= column._pages[pagePos].MinIndex && row <= column._pages[pagePos].MaxIndex);
+    }
+
+    internal void Clear(int fromRow, int fromCol, int rows, int columns)
         {
             Delete(fromRow, fromCol, rows, columns, false);
         }

--- a/EPPlus/DataValidation/ExcelDataValidationCollection.cs
+++ b/EPPlus/DataValidation/ExcelDataValidationCollection.cs
@@ -107,6 +107,8 @@ namespace OfficeOpenXml.DataValidation
             {
                 OnValidationCountChanged();
             }
+
+            InternalValidationEnabled = true;
         }
 
         private void EnsureRootElementExists()
@@ -161,6 +163,8 @@ namespace OfficeOpenXml.DataValidation
         {
             Require.Argument(address).IsNotNullOrEmpty("address");
 
+            if (!InternalValidationEnabled) return;
+
             // ensure that the new address does not collide with an existing validation.
             var newAddress = new ExcelAddress(address);
             if (_validations.Count > 0)
@@ -190,6 +194,8 @@ namespace OfficeOpenXml.DataValidation
         /// </summary>
         internal void ValidateAll()
         {
+            if (!InternalValidationEnabled) return;
+
             foreach (var validation in _validations)
             {
                 validation.Validate();
@@ -342,6 +348,18 @@ namespace OfficeOpenXml.DataValidation
         public int Count
         {
             get { return _validations.Count; }
+        }
+
+
+        /// <summary>
+        /// Epplus validates that all data validations are consistend and valid
+        /// when they are added and when a workbook is saved. Since this takes some
+        /// resources, it can be disabled for improve performance. 
+        /// </summary>
+        public bool InternalValidationEnabled
+        {
+            get;
+            set;
         }
 
         /// <summary>

--- a/EPPlus/DataValidation/ExcelDataValidationCollection.cs
+++ b/EPPlus/DataValidation/ExcelDataValidationCollection.cs
@@ -71,6 +71,7 @@ namespace OfficeOpenXml.DataValidation
     public class ExcelDataValidationCollection : XmlHelper, IEnumerable<IExcelDataValidation>
     {
         private List<IExcelDataValidation> _validations = new List<IExcelDataValidation>();
+        private ValidationStore _validationStore = new ValidationStore();
         private ExcelWorksheet _worksheet = null;
 
         private const string DataValidationPath = "//d:dataValidations";
@@ -100,15 +101,26 @@ namespace OfficeOpenXml.DataValidation
                     var typeSchema = node.Attributes["type"] != null ? node.Attributes["type"].Value : "";
 
                     var type = ExcelDataValidationType.GetBySchemaName(typeSchema);
-                    _validations.Add(ExcelDataValidationFactory.Create(type, worksheet, addr, node));
+                    AddValidation(ExcelDataValidationFactory.Create(type, worksheet, addr, node));
+
+                    InternalValidationEnabled = true;
                 }
             }
-            if (_validations.Count > 0)
-            {
-                OnValidationCountChanged();
-            }
+        }
 
-            InternalValidationEnabled = true;
+        private void AddValidation(IExcelDataValidation validation)
+        {
+            _validations.Add(validation);
+            _validationStore.Add(validation);
+            OnValidationCountChanged();
+        }
+
+        private bool RemoveValidation(IExcelDataValidation validation)
+        {
+            var retVal = _validations.Remove(validation);
+            _validationStore.Remove(validation);
+            if (retVal) OnValidationCountChanged();
+            return retVal;
         }
 
         private void EnsureRootElementExists()
@@ -159,34 +171,28 @@ namespace OfficeOpenXml.DataValidation
         /// </summary>
         /// <param name="address"></param>
         /// <param name="validatingValidation"></param>
-        private void ValidateAddress(string address, IExcelDataValidation validatingValidation)
+        private void ValidateAddress(ExcelAddressBase address, IExcelDataValidation validatingValidation)
         {
-            Require.Argument(address).IsNotNullOrEmpty("address");
-
             if (!InternalValidationEnabled) return;
 
             // ensure that the new address does not collide with an existing validation.
-            var newAddress = new ExcelAddress(address);
             if (_validations.Count > 0)
             {
-                foreach (var validation in _validations)
+                var collision = _validationStore.FindCollisions(address, validatingValidation).FirstOrDefault();
+
+                if (collision != null)
                 {
-                    if (validatingValidation != null && validatingValidation == validation)
-                    {
-                        continue;
-                    }
-                    var result = validation.Address.Collide(newAddress);
-                    if (result != ExcelAddressBase.eAddressCollition.No)
-                    {
-                         throw new InvalidOperationException(string.Format("The address ({0}) collides with an existing validation ({1})", address, validation.Address.Address));
-                    }
+                    throw new InvalidOperationException(string.Format("The address ({0}) collides with an existing validation ({1})", address, collision.Address.Address));
                 }
             }
         }
 
         private void ValidateAddress(string address)
         {
-            ValidateAddress(address, null);
+            Require.Argument(address).IsNotNullOrEmpty("address");
+            var newAddress = new ExcelAddress(address);
+
+            ValidateAddress(newAddress, null);
         }
 
         /// <summary>
@@ -200,7 +206,7 @@ namespace OfficeOpenXml.DataValidation
             {
                 validation.Validate();
 
-                ValidateAddress(validation.Address.Address, validation);
+                ValidateAddress(validation.Address, validation);
             }
         }
 
@@ -214,8 +220,7 @@ namespace OfficeOpenXml.DataValidation
             ValidateAddress(address);
             EnsureRootElementExists();
             var item = new ExcelDataValidationAny(_worksheet, address, ExcelDataValidationType.Any);
-            _validations.Add(item);
-            OnValidationCountChanged();
+            AddValidation(item);
             return item;
         }
 
@@ -229,8 +234,7 @@ namespace OfficeOpenXml.DataValidation
             ValidateAddress(address);
             EnsureRootElementExists();
             var item = new ExcelDataValidationInt(_worksheet, address, ExcelDataValidationType.Whole);
-            _validations.Add(item);
-            OnValidationCountChanged();
+            AddValidation(item);
             return item;
         }
 
@@ -245,8 +249,7 @@ namespace OfficeOpenXml.DataValidation
             ValidateAddress(address);
             EnsureRootElementExists();
             var item = new ExcelDataValidationDecimal(_worksheet, address, ExcelDataValidationType.Decimal);
-            _validations.Add(item);
-            OnValidationCountChanged();
+            AddValidation(item);
             return item;
         }
 
@@ -261,8 +264,7 @@ namespace OfficeOpenXml.DataValidation
             ValidateAddress(address);
             EnsureRootElementExists();
             var item = new ExcelDataValidationList(_worksheet, address, ExcelDataValidationType.List);
-            _validations.Add(item);
-            OnValidationCountChanged();
+            AddValidation(item);
             return item;
         }
 
@@ -276,8 +278,7 @@ namespace OfficeOpenXml.DataValidation
             ValidateAddress(address);
             EnsureRootElementExists();
             var item = new ExcelDataValidationInt(_worksheet, address, ExcelDataValidationType.TextLength);
-            _validations.Add(item);
-            OnValidationCountChanged();
+            AddValidation(item);
             return item;
         }
 
@@ -291,8 +292,7 @@ namespace OfficeOpenXml.DataValidation
             ValidateAddress(address);
             EnsureRootElementExists();
             var item = new ExcelDataValidationDateTime(_worksheet, address, ExcelDataValidationType.DateTime);
-            _validations.Add(item);
-            OnValidationCountChanged();
+            AddValidation(item);
             return item;
         }
 
@@ -302,8 +302,7 @@ namespace OfficeOpenXml.DataValidation
             ValidateAddress(address);
             EnsureRootElementExists();
             var item = new ExcelDataValidationTime(_worksheet, address, ExcelDataValidationType.Time);
-            _validations.Add(item);
-            OnValidationCountChanged();
+            AddValidation(item);
             return item;
         }
         /// <summary>
@@ -316,8 +315,7 @@ namespace OfficeOpenXml.DataValidation
             ValidateAddress(address);
             EnsureRootElementExists();
             var item = new ExcelDataValidationCustom(_worksheet, address, ExcelDataValidationType.Custom);
-            _validations.Add(item);
-            OnValidationCountChanged();
+            AddValidation(item);
             return item;
         }
 
@@ -337,9 +335,7 @@ namespace OfficeOpenXml.DataValidation
             //TopNode.RemoveChild(((ExcelDataValidation)item).TopNode);
             var dvNode = _worksheet.WorksheetXml.DocumentElement.SelectSingleNode(DataValidationPath.TrimStart('/'), NameSpaceManager);
             dvNode?.RemoveChild(((ExcelDataValidation)item).TopNode);
-            var retVal = _validations.Remove(item);
-            if (retVal) OnValidationCountChanged();
-            return retVal;
+            return RemoveValidation(item);
         }
 
         /// <summary>
@@ -437,6 +433,7 @@ namespace OfficeOpenXml.DataValidation
                 //}
             }
             _validations.RemoveAll(match);
+            matches.ForEach(m => _validationStore.Remove(m));
             OnValidationCountChanged();
         }
 

--- a/EPPlus/DataValidation/ValidationStore.cs
+++ b/EPPlus/DataValidation/ValidationStore.cs
@@ -1,0 +1,227 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using OfficeOpenXml.DataValidation.Contracts;
+
+namespace OfficeOpenXml.DataValidation
+{
+    /// <summary>
+    /// Manages list of <see cref="IExcelDataValidation"/> objects partially ordered by their addresses.
+    /// It uses binary search to find matching validation, thus reducing search complexity to O(log(N)) instead of O(N).
+    /// </summary>
+    internal class ValidationStore
+    {
+        private struct ValidationInfo
+        {
+            public IExcelDataValidation Validation { get; }
+            public ExcelAddressBase Address { get; }
+
+            public ValidationInfo(IExcelDataValidation validation) : this()
+            {
+                this.Validation = validation;
+                this.Address = validation.Address;
+            }
+
+            public ValidationInfo(ExcelAddressBase address) : this()
+            {
+                this.Validation = null;
+                this.Address = address;
+            }
+        }
+
+        /// <summary>
+        /// Manages list of <see cref="IExcelDataValidation"/> objects partially ordered by address projection.
+        /// Projection is defined by axis X (columns) or Y (rows).
+        /// </summary>
+        private class PartiallyOrderedValidationList
+        {
+            private static readonly IExcelDataValidation[] Empty = new IExcelDataValidation[0];
+
+            private readonly List<ValidationInfo> items = new List<ValidationInfo>();
+            private readonly IComparer<ValidationInfo> comparer;
+
+            public PartiallyOrderedValidationList(IComparer<ValidationInfo> comparer)
+            {
+                this.comparer = comparer;
+            }
+
+            public void Add(IExcelDataValidation validation)
+            {
+                var item = new ValidationInfo(validation);
+                var index = this.items.BinarySearch(item, this.comparer);
+
+                if (index >= 0)
+                {
+                    this.items.Insert(index, item);
+                }
+                else
+                {
+                    index = ~index;
+
+                    if (index == this.items.Count)
+                    {
+                        this.items.Add(item);
+                    }
+                    else
+                    {
+                        this.items.Insert(index, item);
+                    }
+                }
+            }
+
+            public bool Remove(IExcelDataValidation validation)
+            {
+                return this.items.RemoveAll(x => x.Validation.Equals(validation)) > 0;
+            }
+
+            public IExcelDataValidation[] FindSame(ExcelAddressBase address)
+            {
+                var item = new ValidationInfo(address);
+                var index = this.items.BinarySearch(item, this.comparer);
+
+                if (index >= 0)
+                {
+                    int left = index;
+                    while (left >= 0 && this.comparer.Compare(this.items[left], item) == 0)
+                    {
+                        left -= 1;
+                    }
+
+                    left += 1;
+
+                    int right = index;
+                    while (right < this.items.Count && this.comparer.Compare(this.items[right], item) == 0)
+                    {
+                        right += 1;
+                    }
+
+                    right -= 1;
+
+                    int resultLength = right - left + 1;
+                    var result = new IExcelDataValidation[resultLength];
+
+                    for (int i = 0; i < resultLength; i++)
+                    {
+                        result[i] = this.items[left + i].Validation;
+                    }
+
+                    return result;
+                }
+                else
+                {
+                    return Empty;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Compares X axis (columns) projections of two ranges x and y.
+        /// 
+        /// Range x is considered to be less than y if end row of x is less than start column of y:
+        /// XXX
+        /// XXX YYY
+        ///     YYY
+        ///       
+        /// Range x is considered to be greater than y if start column of x is greater than end column of y:
+        /// YYY
+        /// YYY XXX
+        ///     XXX
+        ///     
+        /// Otherwise, ranges are considered equal. This means their projections have non-empty intersection area:
+        /// XXX
+        /// XXX
+        ///   YYY
+        ///   YYY
+        /// </summary>
+        private class ExcelDataValidationColumnComparer : IComparer<ValidationInfo>
+        {
+            public int Compare(ValidationInfo x, ValidationInfo y)
+            {
+                var addressX = x.Address;
+                var addressY = y.Address;
+
+                if (addressX.Start.Column + addressX.Columns - 1 < addressY.Start.Column)
+                {
+                    return 1;
+                }
+
+                if (addressY.Start.Column + addressY.Columns - 1 < addressX.Start.Column)
+                {
+                    return -1;
+                }
+
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Compares Y axis (rows) projections of two ranges x and y.
+        /// 
+        /// Range x is considered to be less than y if end row of x is less than start row of y:
+        /// XXX
+        /// XXX
+        ///   YYY
+        ///   YYY
+        /// 
+        /// Range x is considered to be greater than y if start row of x is greater than end row of y:
+        /// YYY
+        /// YYY
+        ///   XXX
+        ///   XXX
+        /// Otherwise, ranges are considered equal. This means their projections have non-empty intersection area:
+        /// XXX
+        /// XXX YYY
+        ///     YYY
+        /// </summary>
+        private class ExcelAddressBaseRowComparer : IComparer<ValidationInfo>
+        {
+            public int Compare(ValidationInfo x, ValidationInfo y)
+            {
+                var addressX = x.Address;
+                var addressY = y.Address;
+
+                if (addressX.Start.Row + addressX.Rows - 1 < addressY.Start.Row)
+                {
+                    return 1;
+                }
+
+                if (addressY.Start.Row + addressY.Rows - 1 < addressX.Start.Row)
+                {
+                    return -1;
+                }
+
+                return 0;
+            }
+        }
+
+        private readonly PartiallyOrderedValidationList projectionsX = new PartiallyOrderedValidationList(new ExcelDataValidationColumnComparer());
+        private readonly PartiallyOrderedValidationList projectionsY = new PartiallyOrderedValidationList(new ExcelAddressBaseRowComparer());
+
+        public void Add(IExcelDataValidation validation)
+        {
+            this.projectionsX.Add(validation);
+            this.projectionsY.Add(validation);
+        }
+
+        public bool Remove(IExcelDataValidation validation)
+        {
+            return this.projectionsX.Remove(validation) && this.projectionsY.Remove(validation);
+        }
+
+        public IEnumerable<IExcelDataValidation> FindCollisions(ExcelAddressBase address, IExcelDataValidation validatingValidation)
+        {
+            var collidingValidationsX = this.projectionsX.FindSame(address);
+            var collidingValidationsY = this.projectionsY.FindSame(address);
+
+            var collidingValidations = collidingValidationsX
+                .Intersect(collidingValidationsY)
+                .Where(x => string.Equals(x.Address.WorkSheet, address.WorkSheet));
+
+            if (validatingValidation != null)
+            {
+                collidingValidations = collidingValidations.Except(new[] { validatingValidation });
+            }
+
+            return collidingValidations;
+        }
+    }
+}

--- a/EPPlus/ExcelRangeBase.cs
+++ b/EPPlus/ExcelRangeBase.cs
@@ -2987,7 +2987,6 @@ namespace OfficeOpenXml
             var formulas = GetItems(_worksheet._formulas, _fromRow, _fromCol, _toRow, _toCol);
             var hyperLinks = GetItems(_worksheet._hyperLinks, _fromRow, _fromCol, _toRow, _toCol);
             var comments = GetItems(_worksheet._commentsStore, _fromRow, _fromCol, _toRow, _toCol);
-            var sf = new HashSet<int>();
             //Sort the values and styles.
             _worksheet._values.Clear(_fromRow, _fromCol, _toRow - _fromRow + 1, cols);
             for (var r = 0; r < l.Count; r++)
@@ -3009,19 +3008,19 @@ namespace OfficeOpenXml
                         _worksheet._formulas.SetValue(row, col, formulas[addr]);
                         if (formulas[addr] is int)
                         {
-                            var sfIx = (int)formulas[addr];
-                            if (!sf.Contains(sfIx))
+                            int sfIx = (int)formulas[addr];
+                            var startAddr = new ExcelAddress(Worksheet._sharedFormulas[sfIx].Address);
+                            var f = Worksheet._sharedFormulas[sfIx];
+                            if (startAddr._fromRow > row)
                             {
-                                var startAddr = new ExcelAddress(Worksheet._sharedFormulas[sfIx].Address);
-                                if (startAddr._fromRow > row)
-                                {
-                                    var f = Worksheet._sharedFormulas[sfIx];
-                                    f.Formula = ExcelCellBase.TranslateFromR1C1(ExcelCellBase.TranslateToR1C1(f.Formula, f.StartRow, f.StartCol), row, f.StartCol);
-                                    f.StartRow = row;
-                                    f.Address = ExcelCellBase.GetAddress(row, col, startAddr._toRow, startAddr._toCol);
-                                }
+                                f.Formula = ExcelCellBase.TranslateFromR1C1(ExcelCellBase.TranslateToR1C1(f.Formula, f.StartRow, f.StartCol), row, f.StartCol);
+                                f.StartRow = row;
+                                f.Address = ExcelCellBase.GetAddress(row, startAddr._fromCol, startAddr._toRow, startAddr._toCol);
                             }
-                            sf.Add(sfIx);
+                            else if (startAddr._toRow < row)
+                            {
+                                f.Address = ExcelCellBase.GetAddress(startAddr._fromRow, startAddr._fromCol, row, startAddr._toCol);
+                            }
                         }
                     }
 

--- a/EPPlus/ExcelWorksheetView.cs
+++ b/EPPlus/ExcelWorksheetView.cs
@@ -368,7 +368,7 @@ namespace OfficeOpenXml
         {
             get
             {
-                return GetXmlNodeBool("@showGridLines");
+                return GetXmlNodeBool("@showGridLines", true);
             }
             set
             {

--- a/EPPlus/FormulaParsing/EpplusExcelDataProvider.cs
+++ b/EPPlus/FormulaParsing/EpplusExcelDataProvider.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/EpplusNameValueProvider.cs
+++ b/EPPlus/FormulaParsing/EpplusNameValueProvider.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
@@ -162,14 +162,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             Functions["vlookup"] = new VLookup();
             Functions["lookup"] = new Lookup();
             Functions["match"] = new Match();
-            Functions["row"] = new Row(){SkipArgumentEvaluation = true};
-            Functions["rows"] = new Rows(){SkipArgumentEvaluation = true};
-            Functions["column"] = new Column(){SkipArgumentEvaluation = true};
-            Functions["columns"] = new Columns(){SkipArgumentEvaluation = true};
+            Functions["row"] = new Row();
+            Functions["rows"] = new Rows();
+            Functions["column"] = new Column();
+            Functions["columns"] = new Columns();
             Functions["choose"] = new Choose();
             Functions["index"] = new Index();
             Functions["indirect"] = new Indirect();
-            Functions["offset"] = new Offset(){SkipArgumentEvaluation = true};
+            Functions["offset"] = new Offset();
             // Date
             Functions["date"] = new Date();
             Functions["today"] = new Today();

--- a/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
@@ -97,7 +97,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         /// Used for some Lookupfunctions to indicate that function arguments should
         /// not be compiled before the function is called.
         /// </summary>
-        public bool SkipArgumentEvaluation { get; set; }
+        //public bool SkipArgumentEvaluation { get; set; }
         protected object GetFirstValue(IEnumerable<FunctionArgument> val)
         {
             var arg = ((IEnumerable<FunctionArgument>)val).FirstOrDefault();
@@ -179,6 +179,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
         protected string ArgToAddress(IEnumerable<FunctionArgument> arguments, int index)
         {            
             return arguments.ElementAt(index).IsExcelRange ? arguments.ElementAt(index).ValueAsRangeInfo.Address.FullAddress : ArgToString(arguments, index);
+        }
+
+        protected string ArgToAddress(IEnumerable<FunctionArgument> arguments, int index, ParsingContext context)
+        {
+            var arg = arguments.ElementAt(index);
+            if(arg.ExcelAddressReferenceId > 0)
+            {
+                return context.AddressCache.Get(arg.ExcelAddressReferenceId);
+            }
+            return ArgToAddress(arguments, index);
         }
 
         /// <summary>

--- a/EPPlus/FormulaParsing/Excel/Functions/FunctionArgument.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/FunctionArgument.cs
@@ -65,6 +65,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
             get { return Value != null ? Value.GetType() : null; }
         }
 
+        public int ExcelAddressReferenceId { get; set; }
+
         public bool IsExcelRange
         {
             get { return Value != null && Value is EpplusExcelDataProvider.IRangeInfo; }

--- a/EPPlus/FormulaParsing/Excel/Functions/Math/CountBlank.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/Math/CountBlank.cs
@@ -1,4 +1,22 @@
-﻿using OfficeOpenXml.FormulaParsing.Excel.Functions.Logical;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2018-12-27
+ *******************************************************************************/
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Logical;
 using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 using System;
 using System.Collections.Generic;

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Column.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Column.cs
@@ -41,7 +41,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             {
                 return CreateResult(context.Scopes.Current.Address.FromCol, DataType.Integer);
             }
-            var rangeAddress = ArgToString(arguments, 0);
+            var rangeAddress = ArgToAddress(arguments, 0, context);
             if (!ExcelAddressUtil.IsValidAddress(rangeAddress))
                 throw new ArgumentException("An invalid argument was supplied");
             var factory = new RangeAddressFactory(context.ExcelDataProvider);

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Columns.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Columns.cs
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             }
             else
             {
-                var range = ArgToString(arguments, 0);
+                var range = ArgToAddress(arguments, 0, context);
                 if (ExcelAddressUtil.IsValidAddress(range))
                 {
                     var factory = new RangeAddressFactory(context.ExcelDataProvider);

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
@@ -55,7 +55,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
         {
             var searchedValue = arguments.ElementAt(0).Value;
             Require.That(arguments.ElementAt(1).Value).Named("firstAddress").IsNotNull();
-            var firstAddress = ArgToString(arguments, 1);
+            var firstAddress = ArgToAddress(arguments, 1, context);
             var rangeAddressFactory = new RangeAddressFactory(context.ExcelDataProvider);
             var address = rangeAddressFactory.Create(firstAddress);
             var nRows = address.ToRow - address.FromRow;
@@ -77,8 +77,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             var searchedValue = arguments.ElementAt(0).Value;
             Require.That(arguments.ElementAt(1).Value).Named("firstAddress").IsNotNull();
             Require.That(arguments.ElementAt(2).Value).Named("secondAddress").IsNotNull();
-            var firstAddress = ArgToString(arguments, 1);
-            var secondAddress = ArgToString(arguments, 2);
+            var firstAddress = ArgToAddress(arguments, 1, context);
+            var secondAddress = ArgToAddress(arguments, 2, context);
             var rangeAddressFactory = new RangeAddressFactory(context.ExcelDataProvider);
             var address1 = rangeAddressFactory.Create(firstAddress);
             var address2 = rangeAddressFactory.Create(secondAddress);

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -51,7 +51,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             ValidateArguments(arguments, 2);
 
             var searchedValue = arguments.ElementAt(0).Value;
-            var address =  ArgToAddress(arguments,1); 
+            var address =  ArgToAddress(arguments,1, context); 
             var rangeAddressFactory = new RangeAddressFactory(context.ExcelDataProvider);
             var rangeAddress = rangeAddressFactory.Create(address);
             var matchType = GetMatchType(arguments);

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
@@ -36,19 +36,19 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
         {
             var functionArguments = arguments as FunctionArgument[] ?? arguments.ToArray();
             ValidateArguments(functionArguments, 3);
-            var startRange = ArgToAddress(functionArguments, 0);
+            var startRange = ArgToAddress(functionArguments, 0, context);
             var rowOffset = ArgToInt(functionArguments, 1);
             var colOffset = ArgToInt(functionArguments, 2);
             int width = 0, height = 0;
             if (functionArguments.Length > 3)
             {
                 height = ArgToInt(functionArguments, 3);
-                ThrowExcelErrorValueExceptionIf(() => height == 0, eErrorType.Ref);
+                if (height == 0) return new CompileResult(eErrorType.Ref);
             }
             if (functionArguments.Length > 4)
             {
                 width = ArgToInt(functionArguments, 4);
-                ThrowExcelErrorValueExceptionIf(() => width == 0, eErrorType.Ref);
+                if (width == 0) return new CompileResult(eErrorType.Ref);
             }
             var ws = context.Scopes.Current.Address.Worksheet;            
             var r =context.ExcelDataProvider.GetRange(ws,startRange);

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
@@ -60,20 +60,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             var toCol = (width != 0 ? adr._fromCol + width - 1 : adr._toCol) + colOffset;
 
             var newRange = context.ExcelDataProvider.GetRange(adr.WorkSheet, fromRow, fromCol, toRow, toCol);
-            if (!newRange.IsMulti)
-            {
-                if (newRange.IsEmpty) return CompileResult.Empty;
-                var val = newRange.GetValue(fromRow, fromCol);
-                if (IsNumeric(val))
-                {
-                    return CreateResult(val, DataType.Decimal);
-                }
-                if (val is ExcelErrorValue)
-                {
-                    return CreateResult(val, DataType.ExcelError);
-                }
-                return CreateResult(val, DataType.String);
-            }
+            
             return CreateResult(newRange, DataType.Enumerable);
         }
     }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Row.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Row.cs
@@ -41,7 +41,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             {
                 return CreateResult(context.Scopes.Current.Address.FromRow, DataType.Integer);
             }
-            var rangeAddress = ArgToString(arguments, 0);
+            var rangeAddress = ArgToAddress(arguments, 0, context);
             if (!ExcelAddressUtil.IsValidAddress(rangeAddress))
                 throw new ArgumentException("An invalid argument was supplied");
             var factory = new RangeAddressFactory(context.ExcelDataProvider);

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Rows.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Rows.cs
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             }
             else
             {
-                var range = ArgToString(arguments, 0);
+                var range = ArgToAddress(arguments, 0, context);
                 if (ExcelAddressUtil.IsValidAddress(range))
                 {
                     var factory = new RangeAddressFactory(context.ExcelDataProvider);

--- a/EPPlus/FormulaParsing/ExcelAddressCache.cs
+++ b/EPPlus/FormulaParsing/ExcelAddressCache.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2018-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/EPPlus/FormulaParsing/ExcelAddressCache.cs
+++ b/EPPlus/FormulaParsing/ExcelAddressCache.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EPPlus.FormulaParsing
+{
+    /// <summary>
+    /// Caches string by generated id's.
+    /// </summary>
+    public class ExcelAddressCache
+    {
+        private readonly object _myLock = new object();
+        private readonly Dictionary<int, string> _addressCache = new Dictionary<int, string>();
+        private readonly Dictionary<string, int> _lookupCache = new Dictionary<string, int>();
+        private int _nextId = 1;
+        private const bool EnableLookupCache = false;
+
+        /// <summary>
+        /// Returns an id to use for caching (when the <see cref="Add"/> method is called)
+        /// </summary>
+        /// <returns></returns>
+        public int GetNewId()
+        {
+            lock(_myLock)
+            {
+                return _nextId++;
+            }
+        }
+
+        /// <summary>
+        /// Adds an address to the cache
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="address"></param>
+        /// <returns></returns>
+        public bool Add(int id, string address)
+        {
+            lock(_myLock)
+            {
+                if (_addressCache.ContainsKey(id)) return false;
+                _addressCache.Add(id, address);
+                if(EnableLookupCache && !_lookupCache.ContainsKey(address))
+                    _lookupCache.Add(address, id);
+                return true;
+            }
+            
+        }
+
+        /// <summary>
+        /// Number of items in the cache
+        /// </summary>
+        public int Count
+        {
+            get { return _addressCache.Count; }
+        }
+
+        /// <summary>
+        /// Returns an address by its cache id
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public string Get(int id)
+        {
+            if (!_addressCache.ContainsKey(id)) return string.Empty;
+            return _addressCache[id];
+        }
+
+        /// <summary>
+        /// Clears the cache
+        /// </summary>
+        public void Clear()
+        {
+            lock(_myLock)
+            {
+                _addressCache.Clear();
+                _lookupCache.Clear();
+                _nextId = 1;
+            }  
+        }
+
+    }
+}

--- a/EPPlus/FormulaParsing/ExcelCalculationOption.cs
+++ b/EPPlus/FormulaParsing/ExcelCalculationOption.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/ExcelCell.cs
+++ b/EPPlus/FormulaParsing/ExcelCell.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/ExcelDataProvider.cs
+++ b/EPPlus/FormulaParsing/ExcelDataProvider.cs
@@ -1,4 +1,22 @@
-﻿using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using OfficeOpenXml.FormulaParsing.LexicalAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EPPlus/FormulaParsing/ExcelValues.cs
+++ b/EPPlus/FormulaParsing/ExcelValues.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ *
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/EPPlus/FormulaParsing/ExpressionGraph/CompileResult.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/CompileResult.cs
@@ -185,5 +185,12 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 		public bool IsResultOfSubtotal { get; set; }
 
         public bool IsHiddenCell { get; set; }
+
+        public int ExcelAddressReferenceId { get; set; }
+
+        public bool IsResultOfResolvedExcelRange
+        {
+            get { return ExcelAddressReferenceId > 0; }
+        }
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/ConstantExpressions.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/ConstantExpressions.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/ExpressionGraph/ExcelAddressExpression.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/ExcelAddressExpression.cs
@@ -82,14 +82,23 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 
         public override CompileResult Compile()
         {
-            if (ParentIsLookupFunction)
+            //if (ParentIsLookupFunction)
+            //{
+            //    return new CompileResult(ExpressionString, DataType.ExcelAddress);
+            //}
+            //else
+            //{
+            //    return CompileRangeValues();
+            //}
+            var cache = _parsingContext.AddressCache;
+            var cacheId = cache.GetNewId();
+            if(!cache.Add(cacheId, ExpressionString))
             {
-                return new CompileResult(ExpressionString, DataType.ExcelAddress);
+                throw new InvalidOperationException("Catastropic error occurred, address caching failed");
             }
-            else
-            {
-                return CompileRangeValues();
-            }
+            var compileResult = CompileRangeValues();
+            compileResult.ExcelAddressReferenceId = cacheId;
+            return compileResult;
         }
 
         private CompileResult CompileRangeValues()

--- a/EPPlus/FormulaParsing/ExpressionGraph/Expression.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/Expression.cs
@@ -58,12 +58,6 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
             Operator = null;
         }
 
-        public virtual bool ParentIsLookupFunction
-        {
-            get;
-            set;
-        }
-
         public virtual bool HasChildren
         {
             get { return _children.Any(); }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionArgumentExpression.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionArgumentExpression.cs
@@ -45,22 +45,6 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
             _function = function;
         }
 
-        public override bool ParentIsLookupFunction
-        {
-            get
-            {
-                return base.ParentIsLookupFunction;
-            }
-            set
-            {
-                base.ParentIsLookupFunction = value;
-                foreach (var child in Children)
-                {
-                    child.ParentIsLookupFunction = value;
-                }
-            }
-        }
-
         public override bool IsGroupedExpression
         {
             get { return false; }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
@@ -54,7 +54,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
                 var compileResult = child.Compile();
                 if (compileResult.IsResultOfSubtotal)
                 {
-                    var arg = new FunctionArgument(compileResult.Result);
+                    var arg = new FunctionArgument(compileResult.Result, compileResult.DataType);
                     arg.SetExcelStateFlag(ExcelCellState.IsResultOfSubtotal);
                     args.Add(arg);
                 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
@@ -39,16 +39,16 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {
     public class DefaultCompiler : FunctionCompiler
     {
-        public DefaultCompiler(ExcelFunction function)
-            : base(function)
+        public DefaultCompiler(ExcelFunction function, ParsingContext context)
+            : base(function, context)
         {
 
         }
 
-        public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
+        public override CompileResult Compile(IEnumerable<Expression> children)
         {
             var args = new List<FunctionArgument>();
-            Function.BeforeInvoke(context);
+            Function.BeforeInvoke(Context);
             foreach (var child in children)
             {
                 var compileResult = child.Compile();
@@ -60,10 +60,10 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
                 }
                 else
                 {
-                    BuildFunctionArguments(compileResult.Result, args);     
+                    BuildFunctionArguments(compileResult, args);     
                 }
             }
-            return Function.Execute(args, context);
+            return Function.Execute(args, Context);
         }
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ErrorHandlingFunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ErrorHandlingFunctionCompiler.cs
@@ -39,21 +39,21 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {
     public class ErrorHandlingFunctionCompiler : FunctionCompiler
     {
-        public ErrorHandlingFunctionCompiler(ExcelFunction function)
-            : base(function)
+        public ErrorHandlingFunctionCompiler(ExcelFunction function, ParsingContext context)
+            : base(function, context)
         {
 
         }
-        public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
+        public override CompileResult Compile(IEnumerable<Expression> children)
         {
             var args = new List<FunctionArgument>();
-            Function.BeforeInvoke(context);
+            Function.BeforeInvoke(Context);
             foreach (var child in children)
             {
                 try
                 {
                     var arg = child.Compile();
-                    BuildFunctionArguments(arg != null ? arg.Result : null, args);
+                    BuildFunctionArguments(arg != null ? arg : null, args);
                 }
                 catch (ExcelErrorValueException efe)
                 {
@@ -65,7 +65,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
                 }
                 
             }
-            return Function.Execute(args, context);
+            return Function.Execute(args, Context);
         }
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompiler.cs
@@ -84,7 +84,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 
         protected void BuildFunctionArguments(CompileResult result, List<FunctionArgument> args)
         {
-            BuildFunctionArguments(result, DataType.Unknown, args);
+            BuildFunctionArguments(result, result.DataType, args);
         }
 
         public abstract CompileResult Compile(IEnumerable<Expression> children);

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/IfErrorFunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/IfErrorFunctionCompiler.cs
@@ -11,18 +11,18 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {
     public class IfErrorFunctionCompiler : FunctionCompiler
     {
-        public IfErrorFunctionCompiler(ExcelFunction function)
-            : base(function)
+        public IfErrorFunctionCompiler(ExcelFunction function, ParsingContext context)
+            : base(function, context)
         {
             Require.That(function).Named("function").IsNotNull();
           
         }
 
-        public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
+        public override CompileResult Compile(IEnumerable<Expression> children)
         {
             if (children.Count() != 2) throw new ExcelErrorValueException(eErrorType.Value);
             var args = new List<FunctionArgument>();
-            Function.BeforeInvoke(context);
+            Function.BeforeInvoke(Context);
             var firstChild = children.First();
             var lastChild = children.ElementAt(1);
             try
@@ -42,7 +42,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
             {
                 args.Add(new FunctionArgument(lastChild.Compile().Result));
             }
-            return Function.Execute(args, context);
+            return Function.Execute(args, Context);
         }
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/IfFunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/IfFunctionCompiler.cs
@@ -47,19 +47,19 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
     /// </summary>
     public class IfFunctionCompiler : FunctionCompiler
     {
-        public IfFunctionCompiler(ExcelFunction function)
-            : base(function)
+        public IfFunctionCompiler(ExcelFunction function, ParsingContext context)
+            : base(function, context)
         {
             Require.That(function).Named("function").IsNotNull();
             if (!(function is If)) throw new ArgumentException("function must be of type If");
         }
 
-        public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
+        public override CompileResult Compile(IEnumerable<Expression> children)
         {
             // 2 is allowed, Excel returns FALSE if false is the outcome of the expression
             if(children.Count() < 2) throw new ExcelErrorValueException(eErrorType.Value);
             var args = new List<FunctionArgument>();
-            Function.BeforeInvoke(context);
+            Function.BeforeInvoke(Context);
             var firstChild = children.ElementAt(0);
             var v = firstChild.Compile().Result;
 
@@ -119,7 +119,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
                 args.Add(new FunctionArgument(null));
                 args.Add(new FunctionArgument(val));
             }
-            return Function.Execute(args, context);
+            return Function.Execute(args, Context);
         }
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/IfNaFunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/IfNaFunctionCompiler.cs
@@ -9,17 +9,17 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {
     public class IfNaFunctionCompiler : FunctionCompiler
     {
-        public IfNaFunctionCompiler(ExcelFunction function)
-            :base(function)
+        public IfNaFunctionCompiler(ExcelFunction function, ParsingContext context)
+            :base(function, context)
         {
             
         }
 
-        public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
+        public override CompileResult Compile(IEnumerable<Expression> children)
         {
             if (children.Count() != 2) return new CompileResult(eErrorType.Value);
             var args = new List<FunctionArgument>();
-            Function.BeforeInvoke(context);
+            Function.BeforeInvoke(Context);
             var firstChild = children.First();
             var lastChild = children.ElementAt(1);
             try
@@ -40,7 +40,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
             {
                 args.Add(new FunctionArgument(lastChild.Compile().Result));
             }
-            return Function.Execute(args, context);
+            return Function.Execute(args, Context);
         }
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/LookupFunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/LookupFunctionCompiler.cs
@@ -38,38 +38,34 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {
     public class LookupFunctionCompiler : FunctionCompiler
     {
-        public LookupFunctionCompiler(ExcelFunction function)
-            : base(function)
+        public LookupFunctionCompiler(ExcelFunction function, ParsingContext context)
+            : base(function, context)
         {
 
         }
 
-        public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
+        public override CompileResult Compile(IEnumerable<Expression> children)
         {
             var args = new List<FunctionArgument>();
-            Function.BeforeInvoke(context);
-            var firstChild = true;
-            foreach (var child in children)
+            Function.BeforeInvoke(Context);
+            for(var x = 0; x < children.Count(); x++)
             {
-                if (!firstChild || Function.SkipArgumentEvaluation)
-                {
-                    child.ParentIsLookupFunction = Function.IsLookupFuction;
-                }
-                else
-                {
-                    firstChild = false;
-                }
+                var child = children.ElementAt(x);
+                //if (x > 0 || Function.SkipArgumentEvaluation)
+                //{
+                //    child.ParentIsLookupFunction = Function.IsLookupFuction;
+                //}
                 var arg = child.Compile();
                 if (arg != null)
                 {
-                    BuildFunctionArguments(arg.Result, arg.DataType, args);
+                    BuildFunctionArguments(arg, arg.DataType, args);
                 }
                 else
                 {
                     BuildFunctionArguments(null, DataType.Unknown, args);
                 } 
             }
-            return Function.Execute(args, context);
+            return Function.Execute(args, Context);
         }
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionExpression.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionExpression.cs
@@ -56,7 +56,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
             : base(expression)
         {
             _parsingContext = parsingContext;
-            _functionCompilerFactory = new FunctionCompilerFactory(parsingContext.Configuration.FunctionRepository);
+            _functionCompilerFactory = new FunctionCompilerFactory(parsingContext.Configuration.FunctionRepository, parsingContext);
             _isNegated = isNegated;
             base.AddChild(new FunctionArgumentExpression(this));
         }
@@ -84,7 +84,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
                     _parsingContext.Configuration.Logger.LogFunction(ExpressionString);
                 }
                 var compiler = _functionCompilerFactory.Create(function);
-                var result = compiler.Compile(HasChildren ? Children : Enumerable.Empty<Expression>(), _parsingContext);
+                var result = compiler.Compile(HasChildren ? Children : Enumerable.Empty<Expression>());
                 if (_isNegated)
                 {
                     if (!result.IsNumeric)

--- a/EPPlus/FormulaParsing/INameValueProvider.cs
+++ b/EPPlus/FormulaParsing/INameValueProvider.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/IParsingLifetimeEventHandler.cs
+++ b/EPPlus/FormulaParsing/IParsingLifetimeEventHandler.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/NameValueProvider.cs
+++ b/EPPlus/FormulaParsing/NameValueProvider.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/ParsedValue.cs
+++ b/EPPlus/FormulaParsing/ParsedValue.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 6
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2018-1-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/ParsingConfiguration.cs
+++ b/EPPlus/FormulaParsing/ParsingConfiguration.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/ParsingContext.cs
+++ b/EPPlus/FormulaParsing/ParsingContext.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/ParsingContext.cs
+++ b/EPPlus/FormulaParsing/ParsingContext.cs
@@ -7,6 +7,7 @@ using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 using OfficeOpenXml.FormulaParsing.ExcelUtilities;
 using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.Logging;
+using EPPlus.FormulaParsing;
 
 namespace OfficeOpenXml.FormulaParsing
 {
@@ -48,6 +49,8 @@ namespace OfficeOpenXml.FormulaParsing
         /// </summary>
         public ParsingScopes Scopes { get; private set; }
 
+        public ExcelAddressCache AddressCache { get; private set; }
+
         /// <summary>
         /// Returns true if a <see cref="IFormulaParserLogger"/> is attached to the parser.
         /// </summary>
@@ -65,12 +68,13 @@ namespace OfficeOpenXml.FormulaParsing
             var context = new ParsingContext();
             context.Configuration = ParsingConfiguration.Create();
             context.Scopes = new ParsingScopes(context);
+            context.AddressCache = new ExcelAddressCache();
             return context;
         }
 
         void IParsingLifetimeEventHandler.ParsingCompleted()
         {
-            
+            AddressCache.Clear();
         }
     }
 }

--- a/EPPlus/FormulaParsing/ParsingScope.cs
+++ b/EPPlus/FormulaParsing/ParsingScope.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/FormulaParsing/ParsingScopes.cs
+++ b/EPPlus/FormulaParsing/ParsingScopes.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/* Copyright (C) 2011  Jan Källman
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied.
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author Change                      Date
+ *******************************************************************************
+ * Mats Alm Added		                2016-12-27
+ *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
+++ b/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
@@ -35,6 +35,8 @@ using System.Text;
 using System.Xml;
 using System.Linq;
 using OfficeOpenXml.Utils;
+using System.Security;
+
 namespace OfficeOpenXml.Table.PivotTable
 {
     public enum eSourceType
@@ -278,9 +280,8 @@ namespace OfficeOpenXml.Table.PivotTable
                 }
                 else
                 {
-                    xml += string.Format("<cacheField name=\"{0}\" numFmtId=\"0\">", sourceWorksheet.GetValueInner(sourceAddress._fromRow, col));
+                    xml += string.Format("<cacheField name=\"{0}\" numFmtId=\"0\">", SecurityElement.Escape(sourceWorksheet.GetValueInner(sourceAddress._fromRow, col).ToString()));
                 }
-                //xml += "<sharedItems containsNonDate=\"0\" containsString=\"0\" containsBlank=\"1\" /> ";
                 xml += "<sharedItems containsBlank=\"1\" /> ";
                 xml += "</cacheField>";
             }

--- a/EPPlusTest/CellStoreTest.cs
+++ b/EPPlusTest/CellStoreTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Drawing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
+using OfficeOpenXml.Style;
 
 namespace EPPlusTest
 {
@@ -184,6 +186,27 @@ namespace EPPlusTest
 
             Assert.AreEqual(ws.Cells["B1"].Value, ws.Cells["D1"].Value);
             Assert.AreNotEqual(ws.Cells["B1"].Formula, ws.Cells["D1"].Formula);
+        }
+        [TestMethod]
+        public void Issues351()
+        {
+            using (var package = new ExcelPackage())
+            {
+                // Arrange
+                var worksheet = package.Workbook.Worksheets.Add("Test");
+                worksheet.Cells[1, 1].Value = "A";                      // If you remove this "anchor", the problem doesn't happen.
+                worksheet.Cells[1026, 1].Value = "B";
+                worksheet.Cells[1026, 2].Value = "B";
+                var range = worksheet.Row(1026);
+                range.Style.Fill.PatternType = ExcelFillStyle.Solid;
+                range.Style.Fill.BackgroundColor.SetColor(Color.FromArgb(255, 255, 0));
+
+                // Act - This should shift the whole row 1026 down 1
+                worksheet.InsertRow(1024, 1);
+
+                // Assert - This value should be null, instead it's "B"
+                Assert.IsNull(worksheet.Cells[1025, 1].Value);
+            }
         }
     }
 }

--- a/EPPlusTest/FormulaParsing/Excel/Functions/FunctionRepositoryTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/FunctionRepositoryTests.cs
@@ -32,7 +32,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
             public TestFunctionModule()
             {
                 var myFunction = new MyFunction();
-                var customCompiler = new MyFunctionCompiler(myFunction);
+                var customCompiler = new MyFunctionCompiler(myFunction, ParsingContext.Create());
                 base.Functions.Add(MyFunction.Name, myFunction);
                 base.CustomCompilers.Add(typeof(MyFunction), customCompiler);
             }
@@ -49,8 +49,8 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
 
         public class MyFunctionCompiler : FunctionCompiler
         {
-            public MyFunctionCompiler(MyFunction function) : base(function) { }
-            public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
+            public MyFunctionCompiler(MyFunction function, ParsingContext context) : base(function, context) { }
+            public override CompileResult Compile(IEnumerable<Expression> children)
             {
                 throw new NotImplementedException();
             }

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/RefAndLookupTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/RefAndLookupTests.cs
@@ -351,7 +351,7 @@ namespace EPPlusTest.Excel.Functions
             Assert.AreEqual(1, result.Result);
         }
 
-        [TestMethod, Ignore]
+        [TestMethod]
         public void MatchShouldHandleAddressOnOtherSheet()
         {
             using (var package = new ExcelPackage())

--- a/EPPlusTest/FormulaParsing/ExcelAddressCacheTests.cs
+++ b/EPPlusTest/FormulaParsing/ExcelAddressCacheTests.cs
@@ -1,0 +1,63 @@
+﻿using EPPlus.FormulaParsing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EPPlusTest.FormulaParsing
+{
+    [TestClass]
+    public class ExcelAddressCacheTests
+    {
+        [TestMethod]
+        public void ShouldGenerateNewIds()
+        {
+            var cache = new ExcelAddressCache();
+            var firstId = cache.GetNewId();
+            Assert.AreEqual(1, firstId);
+
+            var secondId = cache.GetNewId();
+            Assert.AreEqual(2, secondId);
+        }
+
+        [TestMethod]
+        public void ShouldReturnCachedAddress()
+        {
+            var cache = new ExcelAddressCache();
+            var id = cache.GetNewId();
+            var address = "A1";
+            var result = cache.Add(id, address);
+            Assert.IsTrue(result);
+            Assert.AreEqual(address, cache.Get(id));
+        }
+
+        [TestMethod]
+        public void AddShouldReturnFalseIfUsedId()
+        {
+            var cache = new ExcelAddressCache();
+            var id = cache.GetNewId();
+            var address = "A1";
+            var result = cache.Add(id, address);
+            Assert.IsTrue(result);
+            var result2 = cache.Add(id, address);
+            Assert.IsFalse(result2);
+        }
+
+        [TestMethod]
+        public void ClearShouldResetId()
+        {
+            var cache = new ExcelAddressCache();
+            var id = cache.GetNewId();
+            Assert.AreEqual(1, id);
+            var address = "A1";
+            var result = cache.Add(id, address);
+            Assert.AreEqual(1, cache.Count);
+            var id2 = cache.GetNewId();
+            Assert.AreEqual(2, id2);
+            cache.Clear();
+            var id3 = cache.GetNewId();
+            Assert.AreEqual(1, id3);
+            
+        }
+    }
+}

--- a/EPPlusTest/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompilerFactoryTests.cs
+++ b/EPPlusTest/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompilerFactoryTests.cs
@@ -18,12 +18,19 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
     [TestClass]
     public class FunctionCompilerFactoryTests
     {
+        private ParsingContext _context;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _context = ParsingContext.Create();
+        }
         #region Create Tests
         [TestMethod]
         public void CreateHandlesStandardFunctionCompiler()
         {
             var functionRepository = FunctionRepository.Create();
-            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository);
+            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository, _context);
             var function = new Sum();
             var functionCompiler = functionCompilerFactory.Create(function);
             Assert.IsInstanceOfType(functionCompiler, typeof(DefaultCompiler));
@@ -33,7 +40,7 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
         public void CreateHandlesSpecialIfCompiler()
         {
             var functionRepository = FunctionRepository.Create();
-            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository);
+            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository, _context);
             var function = new If();
             var functionCompiler = functionCompilerFactory.Create(function);
             Assert.IsInstanceOfType(functionCompiler, typeof(IfFunctionCompiler));
@@ -43,7 +50,7 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
         public void CreateHandlesSpecialIfErrorCompiler()
         {
             var functionRepository = FunctionRepository.Create();
-            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository);
+            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository, _context);
             var function = new IfError();
             var functionCompiler = functionCompilerFactory.Create(function);
             Assert.IsInstanceOfType(functionCompiler, typeof(IfErrorFunctionCompiler));
@@ -53,7 +60,7 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
         public void CreateHandlesSpecialIfNaCompiler()
         {
             var functionRepository = FunctionRepository.Create();
-            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository);
+            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository, _context);
             var function = new IfNa();
             var functionCompiler = functionCompilerFactory.Create(function);
             Assert.IsInstanceOfType(functionCompiler, typeof(IfNaFunctionCompiler));
@@ -63,7 +70,7 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
         public void CreateHandlesLookupFunctionCompiler()
         {
             var functionRepository = FunctionRepository.Create();
-            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository);
+            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository, _context);
             var function = new Column();
             var functionCompiler = functionCompilerFactory.Create(function);
             Assert.IsInstanceOfType(functionCompiler, typeof(LookupFunctionCompiler));
@@ -73,7 +80,7 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
         public void CreateHandlesErrorFunctionCompiler()
         {
             var functionRepository = FunctionRepository.Create();
-            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository);
+            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository, _context);
             var function = new IsError();
             var functionCompiler = functionCompilerFactory.Create(function);
             Assert.IsInstanceOfType(functionCompiler, typeof(ErrorHandlingFunctionCompiler));
@@ -83,8 +90,8 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
         public void CreateHandlesCustomFunctionCompiler()
         {
             var functionRepository = FunctionRepository.Create();
-            functionRepository.LoadModule(new TestFunctionModule());
-            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository);
+            functionRepository.LoadModule(new TestFunctionModule(_context));
+            var functionCompilerFactory = new FunctionCompilerFactory(functionRepository, _context);
             var function = new MyFunction();
             var functionCompiler = functionCompilerFactory.Create(function);
             Assert.IsInstanceOfType(functionCompiler, typeof(MyFunctionCompiler));
@@ -94,10 +101,10 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
         #region Nested Classes
         public class TestFunctionModule : FunctionsModule
         {
-            public TestFunctionModule()
+            public TestFunctionModule(ParsingContext context)
             {
                 var myFunction = new MyFunction();
-                var customCompiler = new MyFunctionCompiler(myFunction);
+                var customCompiler = new MyFunctionCompiler(myFunction, context);
                 base.Functions.Add(MyFunction.Name, myFunction);
                 base.CustomCompilers.Add(typeof(MyFunction), customCompiler);
             }
@@ -114,8 +121,8 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
 
         public class MyFunctionCompiler : FunctionCompiler
         {
-            public MyFunctionCompiler(MyFunction function) : base(function) { }
-            public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
+            public MyFunctionCompiler(MyFunction function, ParsingContext context) : base(function, context) { }
+            public override CompileResult Compile(IEnumerable<Expression> children)
             {
                 throw new NotImplementedException();
             }

--- a/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/MathFunctionsTests.cs
+++ b/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/MathFunctionsTests.cs
@@ -12,11 +12,20 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
     [TestClass]
     public class MathFunctionsTests : FormulaParserTestBase
     {
+        private ExcelPackage _package;
+
         [TestInitialize]
         public void Setup()
         {
-            var excelDataProvider = A.Fake<ExcelDataProvider>();
+            _package = new ExcelPackage();
+            var excelDataProvider = new EpplusExcelDataProvider(_package);
             _parser = new FormulaParser(excelDataProvider);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _package.Dispose();
         }
 
         [TestMethod]
@@ -388,6 +397,20 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
                 sheet.Cells["A5"].Formula = "COUNTBLANK(A1:B4)";
                 sheet.Calculate();
                 Assert.AreEqual(7, sheet.Cells["A5"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void CountBlankShouldCalculateResultOfOffset()
+        {
+            using (var pck = new ExcelPackage())
+            {
+                var sheet = pck.Workbook.Worksheets.Add("test");
+                sheet.Cells["A1"].Value = 1;
+                sheet.Cells["B2"].Value = string.Empty;
+                sheet.Cells["A5"].Formula = "COUNTBLANK(OFFSET(A1, 0, 1))";
+                sheet.Calculate();
+                Assert.AreEqual(1, sheet.Cells["A5"].Value);
             }
         }
 

--- a/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/RefAndLookupTests.cs
+++ b/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/RefAndLookupTests.cs
@@ -21,11 +21,12 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
         [TestInitialize]
         public void Initialize()
         {
-            _excelDataProvider = A.Fake<ExcelDataProvider>();
-            A.CallTo(() => _excelDataProvider.GetDimensionEnd(A<string>.Ignored)).Returns(new ExcelCellAddress(10, 1));
-            _parser = new FormulaParser(_excelDataProvider);
             _package = new ExcelPackage();
             _worksheet = _package.Workbook.Worksheets.Add("Test");
+            _excelDataProvider = A.Fake<ExcelDataProvider>();
+            A.CallTo(() => _excelDataProvider.GetDimensionEnd(A<string>.Ignored)).Returns(new ExcelCellAddress(10, 1));
+            A.CallTo(() => _excelDataProvider.GetWorkbookNameValues()).Returns(new ExcelNamedRangeCollection(_package.Workbook));
+            _parser = new FormulaParser(_excelDataProvider);    
         }
 
         [TestCleanup]
@@ -88,27 +89,42 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
         public void HLookupShouldReturnClosestValueBelowIfLastArgIsTrue()
         {
             var lookupAddress = "A1:B2";
-            A.CallTo(() => _excelDataProvider.GetDimensionEnd(A<string>.Ignored)).Returns(new ExcelCellAddress(5, 5));
-            A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,1, 1)).Returns(3);
-            A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,1, 2)).Returns(5);
-            A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,2, 1)).Returns(1);
-            A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,2, 2)).Returns(2);
-            var result = _parser.Parse("HLOOKUP(4, " + lookupAddress + ", 2, true)");
-            Assert.AreEqual(1, result);
+            using (var package = new ExcelPackage())
+            {
+                var s = package.Workbook.Worksheets.Add("test");
+                s.Cells[1, 1].Value = 3;
+                s.Cells[1, 2].Value = 5;
+                s.Cells[2, 1].Value = 1;
+                s.Cells[2, 2].Value = 2;
+                s.Cells[5, 5].Formula = "HLOOKUP(4, " + lookupAddress + ", 2, true)";
+                s.Calculate();
+                Assert.AreEqual(1, s.Cells[5,5].Value);
+            }
         }
 
         [TestMethod]
         public void LookupShouldReturnMatchingValue()
         {
             var lookupAddress = "A1:B2";
-            A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,1, 1)).Returns(3);
-            A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,1, 2)).Returns(5);
-            A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,2, 1)).Returns(4);
-            A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,2, 2)).Returns(1);
-            var result = _parser.Parse("LOOKUP(4, " + lookupAddress + ")");
-            Assert.AreEqual(1, result);
+            using (var package = new ExcelPackage())
+            {
+                var s = package.Workbook.Worksheets.Add("test");
+                s.Cells[1, 1].Value = 3;
+                s.Cells[1, 2].Value = 5;
+                s.Cells[2, 1].Value = 4;
+                s.Cells[2, 2].Value = 1;
+                s.Cells[5, 5].Formula = "LOOKUP(4, " + lookupAddress + ")";
+                s.Calculate();
+                Assert.AreEqual(1, s.Cells[5, 5].Value);
+            }
+            //    A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,1, 1)).Returns(3);
+            //A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,1, 2)).Returns(5);
+            //A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,2, 1)).Returns(4);
+            //A.CallTo(() => _excelDataProvider.GetCellValue(WorksheetName,2, 2)).Returns(1);
+            //var result = _parser.Parse("LOOKUP(4, " + lookupAddress + ")");
+            //Assert.AreEqual(1, result);
         }
-
+           
         [TestMethod]
         public void MatchShouldReturnIndexOfMatchingValue()
         {
@@ -230,6 +246,21 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
                 s1.Cells["B2"].Value = 1d;
                 s1.Cells["B3"].Value = 1d;
                 s1.Cells["A5"].Formula = "SUM(OFFSET(A1:A3, 0, 1))";
+                s1.Calculate();
+                Assert.AreEqual(3d, s1.Cells["A5"].Value);
+            }
+        }
+
+        [TestMethod]
+        public void OffsetShouldReturnARange2()
+        {
+            using (var package = new ExcelPackage())
+            {
+                var s1 = package.Workbook.Worksheets.Add("Test");
+                s1.Cells["B1"].Value = 10d;
+                s1.Cells["B2"].Value = 10d;
+                s1.Cells["B3"].Value = 10d;
+                s1.Cells["A5"].Formula = "COUNTA(OFFSET(Test!B1, 0, 0, Test!B2, Test!B3))";
                 s1.Calculate();
                 Assert.AreEqual(3d, s1.Cells["A5"].Value);
             }

--- a/EPPlusTest/Issues.cs
+++ b/EPPlusTest/Issues.cs
@@ -2347,7 +2347,7 @@ namespace EPPlusTest
         [TestMethod]
         public void Issue367()
         {
-            using(var pck = new ExcelPackage(new FileInfo(@"c:\Temp\ProductFunctionTest.xlsx")))
+            using(var pck = OpenTemplatePackage(@"ProductFunctionTest.xlsx"))
             {
                 var sheet = pck.Workbook.Worksheets.First();
                 //sheet.Cells["B13"].Value = null;
@@ -2357,6 +2357,18 @@ namespace EPPlusTest
                 sheet.Calculate();
 
                 Assert.AreEqual(0d, sheet.Cells["B16"].Value);
+            }
+        }
+        [TestMethod]
+        public void Issue345()
+        {
+            using (ExcelPackage package = OpenTemplatePackage("issue345.xlsx"))
+            {
+	            var worksheet = package.Workbook.Worksheets["test"];
+                int[] sortColumns = new int[1];
+                sortColumns[0] = 0;	
+	            worksheet.Cells["A2:A30864"].Sort(sortColumns);
+                package.Save();
             }
         }
     }

--- a/EPPlusTest/WorkSheet.cs
+++ b/EPPlusTest/WorkSheet.cs
@@ -3141,7 +3141,19 @@ namespace EPPlusTest
                 package.Save();
             }
         }
-
+        [TestMethod]
+        public void ShowGridlines()
+        {
+            using (var p = OpenPackage("ShowGridlines.xlsx"))
+            {
+                var ws = p.Workbook.Worksheets.Add("sort");
+                Assert.IsTrue(ws.View.ShowGridLines);   //Default true
+                ws.View.ShowGridLines = false;
+                Assert.IsFalse(ws.View.ShowGridLines);
+                ws.View.ShowGridLines = true;
+                Assert.IsTrue(ws.View.ShowGridLines);
+            }
+        }
         private static void AddSortingData(ExcelWorksheet ws, int row, int col)
         {
             var rand = new Random();

--- a/EPPlusTest/WorkSheet.cs
+++ b/EPPlusTest/WorkSheet.cs
@@ -1136,7 +1136,7 @@ namespace EPPlusTest
         {
             _pck = new ExcelPackage();
             var ws = _pck.Workbook.Worksheets.Add("PivotTable");
-            ws.Cells["A1"].LoadFromArrays(new object[][] { new[] { "A", "B", "C", "D" } });
+            ws.Cells["A1"].LoadFromArrays(new object[][] { new[] { "A&B", "B\"", "C'", "<D>" } });
             ws.Cells["A2"].LoadFromArrays(new object[][]
             {
                 new object [] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },


### PR DESCRIPTION
There is a known issue  #151 related with bad performance of **Save** method if there are many validations in the workbook. Usually proposed fix is just to disable validating validation by providing a Boolean parameter to the **Save** method.
But the root of performance problem in the **ExcelDataValidationCollection** class. There is a **ValidateAddress** method which is invoked whenever validation is added or when workbook is saved. To determine if provided address collides with any of existing ones, one just iterates over all existing validations, comparing their range with a provided address. Obviously, the time complexity of linear search in O(N).
The proposed solution is to reduce complexity of search algorithm. By defining a well-order relation on a set of addresses, we can store validations in an **ordered** list. This enables to use a **binary search** to find matching validation, thus reducing search complexity to O(log(N)) instead of O(N).

All unit tests related with validations are passing.

### Example
Consider we have to create and save workbook with **1000** validations. Let's estimate count of address comparisons in the original implementation.
When Nth validation is added, there are already N-1 validations in the collection, so number of comparisons is N-1. By adding 1000 validations one performs 0 + 1 + 2 + ... + 999 address comparisons. Total is `(N-1)*(N-2)/2` equivalent to (N^2)/2.
When workbook is saved, each validation is compared with each one except itself, so total number is `N*(N-1)` equivalent to N^2.
Grand total is `(N^2)/2 + N^2 = 3/2*(N^2)`. If N = 1000 we get 1500000 address comparisons.

Now perform same calculations in proposed implementation.
Adding Nth item to the ordered list requires log(N) comparisons. Before adding the item validation across all existing items is performed to ensure there are no address collisions, which requires `2*log(N)` comparisons more (as we manage two axes internally). Upper esimate of total number of comparisons is `3*N*log(N)`. On workbook saving, total number of comparisons is `2*N*log(N)`. So, grand total is `5*N*log(N)`. If N = 1000 we get `5*1000*7 = 35000` address comparisons.