### PR TITLE
Fix for crashing Excel file generated when making Pivots with SubTotalFunctions property to eSubTotalFunctions.None

### DIFF
--- a/EPPlus/EPPlus.MultiTarget.csproj
+++ b/EPPlus/EPPlus.MultiTarget.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net35;net40</TargetFrameworks>
-    <AssemblyVersion>4.5.3</AssemblyVersion>
-    <FileVersion>4.5.3</FileVersion>
-    <Version>4.5.3</Version>
+    <AssemblyVersion>4.5.3.1</AssemblyVersion>
+    <FileVersion>4.5.3.1</FileVersion>
+    <Version>4.5.3.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://www.gnu.org/licenses/lgpl-3.0.en.html</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/JanKallman/EPPlus</PackageProjectUrl>

--- a/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
+++ b/EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
@@ -282,7 +282,7 @@ namespace OfficeOpenXml.Table.PivotTable
                 {
                     xml += string.Format("<cacheField name=\"{0}\" numFmtId=\"0\">", SecurityElement.Escape(sourceWorksheet.GetValueInner(sourceAddress._fromRow, col).ToString()));
                 }
-                xml += "<sharedItems containsBlank=\"1\" /> ";
+                xml += "<sharedItems count=\"1\"><s v=\"\"/></sharedItems>";
                 xml += "</cacheField>";
             }
             xml += "</cacheFields>";

--- a/EPPlus/Table/PivotTable/ExcelPivotTableField.cs
+++ b/EPPlus/Table/PivotTable/ExcelPivotTableField.cs
@@ -442,8 +442,8 @@ namespace OfficeOpenXml.Table.PivotTable
                  {
                      // for no subtotals, set defaultSubtotal to off
                      SetXmlNodeBool("@defaultSubtotal", false);
-                     TopNode.InnerXml = "";
-                 }
+                     TopNode.InnerXml = "<items count=\"1\"><item x=\"0\"/></items>";
+                }
                  else
                  {
                      string innerXml = "";

--- a/EPPlus/Table/PivotTable/ExcelPivotTableField.cs
+++ b/EPPlus/Table/PivotTable/ExcelPivotTableField.cs
@@ -443,7 +443,7 @@ namespace OfficeOpenXml.Table.PivotTable
                      // for no subtotals, set defaultSubtotal to off
                      SetXmlNodeBool("@defaultSubtotal", false);
                      TopNode.InnerXml = "<items count=\"1\"><item x=\"0\"/></items>";
-                }
+                 }
                  else
                  {
                      string innerXml = "";


### PR DESCRIPTION
Using information from Microsoft engineer, fixed #389 by adjusting XML output:

**Table/PivotTable/ExcelPivotTableField.cs**
Changed what is output when SubTotalFunctions property is set eSubTotalFunctions.None to produce at least one child item

**Table/PivotTable/ExcelPivotCacheDefinition.cs**
Changed what is output in sharedItems, in light of changes to pivotField when there is an empty item.

These fixes are to bring the files into better compliance with format of file as generated by Excel. 

Meanwhile, Microsoft is changing their code to handle previously created files better in coming builds, but they strongly advised that the generation of XML is adjusted in the way this fix does.