### PR TITLE
Make scatter chart markers transparent

### DIFF
--- a/EPPlus/Drawing/Chart/ExcelScatterChartSerie.cs
+++ b/EPPlus/Drawing/Chart/ExcelScatterChartSerie.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
  * You may amend and distribute as you like, but don't remove this header!
  *
  * EPPlus provides server-side generation of Excel 2007/2010 spreadsheets.
@@ -200,7 +200,9 @@ namespace OfficeOpenXml.Drawing.Chart
                 SetXmlNodeString(MARKERSIZE_PATH, size.ToString(), true);
             }
         }
+
         string MARKERCOLOR_PATH = "c:marker/c:spPr/a:solidFill/a:srgbClr/@val";
+        string MARKERCOLOR_NOFILL_PATH = "c:marker/c:spPr/a:noFill";
         /// <summary>
         /// Marker color.
         /// </summary>
@@ -212,6 +214,12 @@ namespace OfficeOpenXml.Drawing.Chart
         {
             get
             {
+                bool noFill = ExistNode(MARKERCOLOR_NOFILL_PATH);
+                if (noFill)
+                {
+                    return Color.Transparent;
+                }
+
                 string color = GetXmlNodeString(MARKERCOLOR_PATH);
                 if (color == "")
                 {
@@ -221,11 +229,7 @@ namespace OfficeOpenXml.Drawing.Chart
                 {
                     Color c = Color.FromArgb(Convert.ToInt32(color, 16));
                     int a = getAlphaChannel(MARKERCOLOR_PATH);
-                    if (a != 255)
-                    {
-                        c = Color.FromArgb(a, c);
-                    }
-                    return c;
+                    return Color.FromArgb(a, c);
                 }
             }
             set
@@ -262,8 +266,10 @@ namespace OfficeOpenXml.Drawing.Chart
                 SetXmlNodeString(LINEWIDTH_PATH, (( int )(12700 * value)).ToString(), true);
             }
         }
+
         //marker line color
         string MARKERLINECOLOR_PATH = "c:marker/c:spPr/a:ln/a:solidFill/a:srgbClr/@val";
+        string MARKERLINECOLOR_NOFILL_PATH = "c:marker/c:spPr/a:ln/a:noFill";
         /// <summary>
         /// Marker Line color.
         /// (not to be confused with LineColor)
@@ -276,6 +282,12 @@ namespace OfficeOpenXml.Drawing.Chart
         {
             get
             {
+                bool noFill = ExistNode(MARKERLINECOLOR_NOFILL_PATH);
+                if (noFill)
+                {
+                    return Color.Transparent;
+                }
+
                 string color = GetXmlNodeString(MARKERLINECOLOR_PATH);
                 if (color == "")
                 {
@@ -285,11 +297,7 @@ namespace OfficeOpenXml.Drawing.Chart
                 {
                     Color c = Color.FromArgb(Convert.ToInt32(color, 16));
                     int a = getAlphaChannel(MARKERLINECOLOR_PATH);
-                    if (a != 255)
-                    {
-                        c = Color.FromArgb(a, c);
-                    }
-                    return c;
+                    return Color.FromArgb(a, c);
                 }
             }
             set


### PR DESCRIPTION
Following the issue https://github.com/JanKallman/EPPlus/issues/400, I fixed 2 things with scatter chart markers: 

- Handle markers transparency
- Fix when marker should be fully opaque but shown as 100% transparent in Excel

**Example of use case** 

I'm reading an already existing and **styled** Excel template including a scatter chart with 3 series :
![image](https://user-images.githubusercontent.com/8690545/52084042-1e368d80-256f-11e9-8680-31e84d4397cd.png)

All I do with EPPlus is read the chart, get the series style (line style + marker style) and add 2 mores series based on an existing serie style. Here is the raw output with EPPlus:

![image](https://user-images.githubusercontent.com/8690545/52084366-f3990480-256f-11e9-81b8-bf4197bb94e9.png)

We can see that I totally lost my markers on blue line and I have some weird black dots on my vertical lines.

Now with the modifications I made, here is the result: 
![image](https://user-images.githubusercontent.com/8690545/52084501-3a86fa00-2570-11e9-895d-409509470e07.png)

Pretty close to what I designed first 👍 




