### PR TITLE
Named range with backslash fix

### DIFF
--- a/EPPlus/FormulaParsing/ExcelUtilities/ExcelAddressUtil.cs
+++ b/EPPlus/FormulaParsing/ExcelUtilities/ExcelAddressUtil.cs
@@ -68,7 +68,7 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
             }
             return OfficeOpenXml.ExcelAddress.IsValidAddress(token);
         }
-        readonly static char[] NameInvalidChars = new char[] { '!', '@', '#', '$', '£', '%', '&', '/', '(', ')', '[', ']', '{', '}', '<', '>', '=', '+', '?', '\\', '*', '-', '~', '^', ':', ';', '|', ',', ' ' };
+        readonly static char[] NameInvalidChars = new char[] { '!', '@', '#', '$', '£', '%', '&', '/', '(', ')', '[', ']', '{', '}', '<', '>', '=', '+', '?', '*', '-', '~', '^', ':', ';', '|', ',', ' ' };
         public static bool IsValidName(string name)
         {
             if (string.IsNullOrEmpty(name))

--- a/EPPlusTest/AddressTests.cs
+++ b/EPPlusTest/AddressTests.cs
@@ -141,6 +141,7 @@ namespace EPPlusTest
             Assert.IsFalse(ExcelAddressUtil.IsValidName("*d"));     //invalid start char
             Assert.IsFalse(ExcelAddressUtil.IsValidName("\t"));     //invalid start char
             Assert.IsFalse(ExcelAddressUtil.IsValidName("\\t"));    //Backslash at least three chars
+            Assert.IsTrue(ExcelAddressUtil.IsValidName("valid\\")); //Backslash not as first char
             Assert.IsFalse(ExcelAddressUtil.IsValidName("A+1"));   //invalid char
             Assert.IsFalse(ExcelAddressUtil.IsValidName("A%we"));   //Address invalid
             Assert.IsFalse(ExcelAddressUtil.IsValidName("BB73"));   //Address invalid


### PR DESCRIPTION
Removed character '\\' as invalid address name. Tables and named ranges can contain backslashes in all position, not only as first character. EPPlus fails to open an excel file with named ranges such as "valid\\".
