### PR TITLE
Rotation of axis caption values

### DIFF
--- a/EPPlus/Drawing/Chart/ExcelChartAxis.cs
+++ b/EPPlus/Drawing/Chart/ExcelChartAxis.cs
@@ -916,5 +916,40 @@ namespace OfficeOpenXml.Drawing.Chart
             } 
         } 
         #endregion 
+        /// <summary>
+        /// Rotation in degrees (0-360)
+        /// </summary>
+        public double Rotation
+        {
+            get
+            {
+                var i = GetXmlNodeInt("c:txPr/a:bodyPr/@rot");
+                if (i < 0)
+                {
+                    return 360 - (i / 60000);
+                }
+                else
+                {
+                    return (i / 60000);
+                }
+            }
+            set
+            {
+                int v;
+                if (value < 0 || value > 360)
+                {
+                    throw (new ArgumentOutOfRangeException("Rotation must be between 0 and 360"));
+                }
+                if (value > 180)
+                {
+                    v = (int)((value - 360) * 60000);
+                }
+                else
+                {
+                    v = (int)(value * 60000);
+                }
+                SetXmlNodeString("c:txPr/a:bodyPr/@rot", v.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
Rotation of axis caption values.
Example in files attached.
before:
![before](https://user-images.githubusercontent.com/3736183/53392379-3fda3780-39aa-11e9-950a-c8f3354e6ee4.png)

after:
![after](https://user-images.githubusercontent.com/3736183/53392377-3f41a100-39aa-11e9-89d9-25e365a9afa8.png)
