### PR TITLE
pagePos=-1 while deleting data

### DIFF
--- a/EPPlus/CellStore.cs
+++ b/EPPlus/CellStore.cs
@@ -976,6 +976,7 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
                                         {
                                             var fr = shift ? fromRow : endRow - rowsLeft;
                                             pagePos = column.GetPosition(fr);
+                                            if (pagePos < 0) pagePos = 0;
                                             delEndRow = DeleteCells(column._pages[pagePos], fr, shift ? fr + rowsLeft : endRow, shift);
                                             if (shift) UpdatePageOffset(column, pagePos, rowsLeft);
                                         }


### PR DESCRIPTION
This is a really crude hack to avoid exceptions. There should be some logging instead :), or may be logic to skip the next 1-2 lines.

[example file.zip](https://github.com/JanKallman/EPPlus/files/2927520/example.file.zip)

```Cs
var excel = new ExcelPackage(new MemoryStream(originalFile)); // any way to load [example file.xlsm] into byte[]
var dataSheet = excel.Workbook.Worksheets["Data"]; // select the sheet
dataSheet.DeleteRow(2, dataSheet.Dimension.End.Row - 1, true); // try to delete all rows below the first
```
Unfortunately, I do not understand all logic in the delete rows procedure, but in my example the **pagePos** became -1 and all crashes.

As I noticed, problem is near marked number and its position on 1000+ row, if I delete it or delete some rows before so its row number became small - there is no error.

![image](https://user-images.githubusercontent.com/3350070/53751246-f2cff700-3ebc-11e9-977f-75f54c776650.png)
