### PR TITLE
_color being null if border tag is empty

### DIFF
--- a/EPPlus/Style/XmlAccess/ExcelBorderItemXml.cs
+++ b/EPPlus/Style/XmlAccess/ExcelBorderItemXml.cs
@@ -127,7 +127,7 @@ namespace OfficeOpenXml.Style.XmlAccess
         {
             ExcelBorderItemXml borderItem = new ExcelBorderItemXml(NameSpaceManager);
             borderItem.Style = _borderStyle;
-            borderItem.Color = _color.Copy();
+            borderItem.Color = Exists ? _color.Copy() : null;
             return borderItem;
         }
 


### PR DESCRIPTION
Hi,

In a generated excel file by a DevExpress library, there might be some border tags in the style that have no content. Reading like this (intended tag in bold):
```
    <borders count="2">
        **<border />**
        <border>
            <left/>
            <right/>
            <top/>
            <bottom style="thin">
                <color indexed="64"/>
            </bottom>
            <diagonal/>
        </border>
    </borders>
```

In which case an NullReferenceException will be thrown when accessing _color.Copy()

The recommended and tested solution is to check for the Exists property before trying to copy the color.

I am sorry for not including a Unit Test, as I am still not so fluent in writing them in .Net

Regards,
