### PR TITLE
Fix Merge Cells issue and add Image Dimensions

### DIFF
--- a/EPPlus/Drawing/ExcelPicture.cs
+++ b/EPPlus/Drawing/ExcelPicture.cs
@@ -38,8 +38,10 @@ using System.IO;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Diagnostics;
+using System.Windows;
 using OfficeOpenXml.Utils;
 using OfficeOpenXml.Compatibility;
+using Size = System.Drawing.Size;
 
 namespace OfficeOpenXml.Drawing
 {
@@ -353,6 +355,16 @@ namespace OfficeOpenXml.Drawing
             get;
             set;
         }
+
+        public Vector GetOffset()
+        {
+            return new Vector(_left, _top);
+        }
+        public Size GetSize()
+        {
+            return new Size(_width, _height);
+        }
+
         /// <summary>
         /// Set the size of the image in percent from the orginal size
         /// Note that resizing columns / rows after using this function will effect the size of the picture

--- a/EPPlus/ExcelWorksheet.cs
+++ b/EPPlus/ExcelWorksheet.cs
@@ -406,6 +406,7 @@ namespace OfficeOpenXml
             _flags = new FlagCellStore();
             _commentsStore = new CellStore<int>();
             _hyperLinks = new CellStore<Uri>();
+            _mergedCells = new MergeCellsCollection();
 
             _names = new ExcelNamedRangeCollection(Workbook, this);
 
@@ -1111,6 +1112,27 @@ namespace OfficeOpenXml
             }
             return (Utils.ConvertUtil._invariantCompareInfo.IsSuffix(xr.LocalName, tagName[0]));
         }
+        private bool ReadUntil(XmlReader xr, int desiredDepth, params string[] tagName)
+        {
+            if (xr.EOF) return false;
+            while (!Array.Exists(tagName, tag => Utils.ConvertUtil._invariantCompareInfo.IsSuffix(xr.LocalName, tag)))
+            {
+                if (xr.Depth == desiredDepth)
+                {
+                    xr.Read();
+                    if (xr.EOF) return false;
+                }
+                else
+                {
+                    while (xr.Depth != desiredDepth)
+                    {
+                        xr.Read();
+                        if (xr.EOF) return false;
+                    }
+                }
+            }
+            return (Utils.ConvertUtil._invariantCompareInfo.IsSuffix(xr.LocalName, tagName[0]));
+        }
         private void LoadColumns(XmlReader xr)//(string xml)
         {
             var colList = new List<IRangeID>();
@@ -1427,7 +1449,7 @@ namespace OfficeOpenXml
         /// <param name="xr"></param>
         private void LoadMergeCells(XmlReader xr)
         {
-            if (ReadUntil(xr, "mergeCells", "hyperlinks", "rowBreaks", "colBreaks") && !xr.EOF)
+            if (ReadUntil(xr, 1, "mergeCells", "hyperlinks", "rowBreaks", "colBreaks") && !xr.EOF)
             {
                 while (xr.Read())
                 {


### PR DESCRIPTION
See issue https://github.com/JanKallman/EPPlus/issues/205

**Merge Cells**
It would appear that in certain circumstances, the `customSheetViews` element in the sheet XML document contains `rowBreaks` which is one of the tags in the argument list passed to the `ReadUntil` method. This method does not consider the depth of the matched tag. If we include a depth property, we can ensure that we'll only match the first level of tags. (IE: `mergeCells`)

Overload the `ReadUntil` method to include a `desiredDepth` property and pass in level 1 in `LoadMergeCells` when calling `ReadUntil`

**Image Dimensions**
Add properties for image dimensions: Properties for a resized image's dimensions are not publicly available.

- [ ] Write a detailed description of your what you have implemented or changed.
- [X] Verify that you only check in the files intended for the pull request.
- [X] Do not change dotnet version, include new dependencies unless you explicitly talked to someone in the project about doing so.
