### PR TITLE
Support Instance_num parameter of SUBSTITUTE function. Fixed issue #530

### DIFF
--- a/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
@@ -176,6 +176,41 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
                     return true;
                 }, "Expecting at least {0} arguments", minLength.ToString());
         }
+
+
+        /// <summary>
+        /// This functions validates that the supplied <paramref name="arguments"/> contains at least
+        /// (the value of) <paramref name="minLength"/> elements. If one of the arguments is an
+        /// <see cref="ExcelDataProvider.IRangeInfo">Excel range</see> the number of cells in
+        /// that range will be counted as well.
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <param name="minLength"></param>
+        /// <param name="length"></param>
+        /// <exception cref="ArgumentException"></exception>
+        protected void ValidateArguments(IEnumerable<FunctionArgument> arguments, int minLength, out int length)
+        {
+            Require.That(arguments).Named("arguments").IsNotNull();
+            var nArgs = 0;
+            ThrowArgumentExceptionIf(() =>
+            {
+                if (arguments.Any())
+                {
+                    foreach (var arg in arguments)
+                    {
+                        nArgs++;
+                        if (arg.IsExcelRange)
+                        {
+                            nArgs += arg.ValueAsRangeInfo.GetNCells();
+                        }
+                    }
+                    if (nArgs >= minLength) return false;
+                }
+                return true;
+            }, "Expecting at least {0} arguments", minLength.ToString());
+            length = nArgs;
+        }
+
         protected string ArgToAddress(IEnumerable<FunctionArgument> arguments, int index)
         {            
             return arguments.ElementAt(index).IsExcelRange ? arguments.ElementAt(index).ValueAsRangeInfo.Address.FullAddress : ArgToString(arguments, index);

--- a/EPPlus/FormulaParsing/Excel/Functions/Text/Substitute.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/Text/Substitute.cs
@@ -34,12 +34,44 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.Text
     {
         public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
         {
-            ValidateArguments(arguments, 3);
+            int argCount;
+            ValidateArguments(arguments, 3, out argCount);
             var text = ArgToString(arguments, 0);
             var find = ArgToString(arguments, 1);
             var replaceWith = ArgToString(arguments, 2);
-            var result = text.Replace(find, replaceWith);
+            string result;
+            if (argCount > 3)
+            {
+                var instanceNum = ArgToInt(arguments, 3);
+                result = ReplaceFirst(text, find, replaceWith, instanceNum);
+            }
+            else
+            {
+                result = text.Replace(find, replaceWith);
+            }
             return CreateResult(result, DataType.String);
+        }
+
+        /// <summary>
+        /// Replaces only the Nth instance of substring.
+        /// </summary>
+        /// <param name="text">String to modify</param>
+        /// <param name="search">Substring to look for</param>
+        /// <param name="replace">Replacement for the matched substring</param>
+        /// <param name="instanceNumber">One-based index of match to replace</param>
+        /// <returns>Modified copy of parameter text where only the specified substring instance has been replaced</returns>
+        private static string ReplaceFirst(string text, string search, string replace, int instanceNumber)
+        {
+            int pos = -1;
+            for (int i=0; i<instanceNumber; i++)
+            {
+                pos = text.IndexOf(search, pos+1);
+            }
+            if (pos < 0)
+            {
+                return text;
+            }
+            return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
         }
     }
 }

--- a/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctionsTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/TextFunctionsTests.cs
@@ -97,6 +97,22 @@ namespace EPPlusTest.Excel.Functions.Text
         }
 
         [TestMethod]
+        public void SubstituteShouldReplaceOnlyFirstInstance()
+        {
+            var func = new Substitute();
+            var result = func.Execute(FunctionsHelper.CreateArgs("testar testar", "es", "xx", 1), _parsingContext);
+            Assert.AreEqual("txxtar testar", result.Result);
+        }
+
+        [TestMethod]
+        public void SubstituteShouldReplaceOnlySecondInstance()
+        {
+            var func = new Substitute();
+            var result = func.Execute(FunctionsHelper.CreateArgs("testar testar", "es", "xx", 2), _parsingContext);
+            Assert.AreEqual("testar txxtar", result.Result);
+        }
+
+        [TestMethod]
         public void ConcatenateShouldConcatenateThreeStrings()
         {
             var func = new Concatenate();

--- a/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/StringFunctionsTests.cs
+++ b/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/StringFunctionsTests.cs
@@ -84,6 +84,13 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
         }
 
         [TestMethod]
+        public void SubstituteShouldReplaceOnlySecondInstanceFound()
+        {
+            var result = _parser.Parse("Substitute(\"testar testar\", \"es\", \"xx\", 2)");
+            Assert.AreEqual("testar txxtar", result);
+        }
+
+        [TestMethod]
         public void ConcatenateShouldReturnAccordingToParams()
         {
             var result = _parser.Parse("CONCATENATE(\"One\", \"Two\", \"Three\")");


### PR DESCRIPTION
Enhances SUBSTITUTE() function with the fourth, optional parameter instance_num.
[https://support.office.com/en-us/article/substitute-function-6434944e-a904-4336-a9b0-1e58df3bc332](https://support.office.com/en-us/article/substitute-function-6434944e-a904-4336-a9b0-1e58df3bc332
)

[Fixes #530](https://github.com/JanKallman/EPPlus/issues/530)

Added three unit tests (TextFunctionsTests.SubstituteShouldReplaceOnlyFirstInstance, TextFunctionsTests.SubstituteShouldReplaceOnlySecondInstance and StringFunctionsTests.SubstituteShouldReplaceOnlySecondInstanceFound) to verify this works.
