### PR TITLE
Fix bug in Series

### DIFF
--- a/EPPlus/Drawing/Chart/ExcelScatterChart.cs
+++ b/EPPlus/Drawing/Chart/ExcelScatterChart.cs
@@ -135,7 +135,7 @@ namespace OfficeOpenXml.Drawing.Chart
             {
                 if (ScatterStyle==eScatterStyle.LineMarker)
                 {
-                    if (((ExcelScatterChartSerie)Series[0]).Marker == eMarkerStyle.None)
+                    if (Series.Count > 0 && ((ExcelScatterChartSerie)Series[0]).Marker == eMarkerStyle.None)
                     {
                         return eChartType.XYScatterLinesNoMarkers;
                     }
@@ -153,7 +153,7 @@ namespace OfficeOpenXml.Drawing.Chart
                 }
                 else if (ScatterStyle == eScatterStyle.SmoothMarker)
                 {
-                    if (((ExcelScatterChartSerie)Series[0]).Marker == eMarkerStyle.None)
+                    if (Series.Count > 0 && ((ExcelScatterChartSerie)Series[0]).Marker == eMarkerStyle.None)
                     {
                         return eChartType.XYScatterSmoothNoMarkers;
                     }


### PR DESCRIPTION
It is possible that Series has no elements. That means that Series[0] cannot be accessed. It was the case in my Excel file that I was working on.

I only have ScatterCharts in my Excel file, thus, if the other charts also assume that Series always has elements, this will fail in those cases.

-[] Write a detailed description of your what you have implemented or changed.
-[] Attach unit tests in the testproject to test implemented functionallity.
-[] Make sure no tests fail in the test project.
-[] Verify that you only check in the files intended for the pull request.
-[] Do not change dotnet version, include new dependencies unless you explicitly talked to someone in the project about doing so.
